### PR TITLE
update company name from backend, remove hardcoded company name

### DIFF
--- a/AirRobeDemo/AirRobeDemo.xcodeproj/project.pbxproj
+++ b/AirRobeDemo/AirRobeDemo.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3C5B27B32760CC29006CB5B6 /* CartPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5B27B22760CC29006CB5B6 /* CartPageViewController.swift */; };
 		3C5B27B62760CC95006CB5B6 /* CartItemView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C5B27B52760CC95006CB5B6 /* CartItemView.xib */; };
 		3C5B27B82760CE3E006CB5B6 /* CartItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5B27B72760CE3E006CB5B6 /* CartItemView.swift */; };
+		3C7CE0BE2880A8D600F65CC8 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7CE0BD2880A8D600F65CC8 /* Utils.swift */; };
 		3C9ADDC6281A04360090B12D /* BrandViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9ADDC5281A04360090B12D /* BrandViewController.swift */; };
 		3C9ADDC8281A04510090B12D /* SubCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9ADDC7281A04510090B12D /* SubCategoryViewController.swift */; };
 		3C9ADDCB281A07BE0090B12D /* SubCategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9ADDC9281A07BE0090B12D /* SubCategoryTableViewCell.swift */; };
@@ -49,6 +50,7 @@
 		3C5B27B22760CC29006CB5B6 /* CartPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartPageViewController.swift; sourceTree = "<group>"; };
 		3C5B27B52760CC95006CB5B6 /* CartItemView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CartItemView.xib; sourceTree = "<group>"; };
 		3C5B27B72760CE3E006CB5B6 /* CartItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartItemView.swift; sourceTree = "<group>"; };
+		3C7CE0BD2880A8D600F65CC8 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		3C9ADDC5281A04360090B12D /* BrandViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandViewController.swift; sourceTree = "<group>"; };
 		3C9ADDC7281A04510090B12D /* SubCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubCategoryViewController.swift; sourceTree = "<group>"; };
 		3C9ADDC9281A07BE0090B12D /* SubCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubCategoryTableViewCell.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				3C5B27AE2760A4CD006CB5B6 /* UIBarButtonItem+Badge.swift */,
 				3C5B27B02760C3CE006CB5B6 /* UserDefaults+Extension.swift */,
 				3CBCFD2F28120B0B00FDD3FC /* UIView+Shadow.swift */,
+				3C7CE0BD2880A8D600F65CC8 /* Utils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -301,6 +304,7 @@
 				3C5B27AA27609D8C006CB5B6 /* Consts.swift in Sources */,
 				3CC9F10D27B5704B006E7D94 /* ProductPageTableViewController.swift in Sources */,
 				3C5B27B12760C3CE006CB5B6 /* UserDefaults+Extension.swift in Sources */,
+				3C7CE0BE2880A8D600F65CC8 /* Utils.swift in Sources */,
 				3C9ADDC6281A04360090B12D /* BrandViewController.swift in Sources */,
 				3C47E5B92810B5D80057519E /* CategoryTableViewCell.swift in Sources */,
 				3CE5468B275B01F000FBE205 /* SceneDelegate.swift in Sources */,

--- a/AirRobeDemo/AirRobeDemo/Application/AppDelegate.swift
+++ b/AirRobeDemo/AirRobeDemo/Application/AppDelegate.swift
@@ -57,7 +57,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AirRobeEventDelegate {
         AirRobeWidget.initialize(
             config: AirRobeWidgetConfig(
                 appId: "515b6ee129da",
-                privacyPolicyURL: "https://www.example.com/privacy-policy",
                 mode: .sandbox
             )
         )

--- a/AirRobeDemo/AirRobeDemo/Controllers/BrandViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/BrandViewController.swift
@@ -15,6 +15,8 @@ final class BrandViewController: UIViewController {
         return tableView
     }()
 
+    var cartButton: UIBarButtonItem?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.setNavigationBarHidden(false, animated: false)
@@ -26,6 +28,26 @@ final class BrandViewController: UIViewController {
         tableView.estimatedRowHeight = 120
         tableView.rowHeight = UITableView.automaticDimension
         view.addSubview(tableView)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        addCartButton()
+    }
+
+    private func addCartButton() {
+        let customButton = UIButton(frame: CGRect.init(x: 0, y: 0, width: 30, height: 30))
+        customButton.setImage(UIImage(named:"cart"), for: .normal)
+        customButton.addTarget(self, action: #selector(onTapCart), for: .touchUpInside)
+        cartButton = UIBarButtonItem(customView: customButton)
+        cartButton?.customView?.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        cartButton?.customView?.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        cartButton?.addBadge(number: UserDefaults.standard.cartItems.count)
+        navigationItem.rightBarButtonItem = cartButton
+    }
+
+    @objc func onTapCart(_ sender: Any) {
+        let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "CartPageViewController") as! CartPageViewController
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     override func viewDidLayoutSubviews() {

--- a/AirRobeDemo/AirRobeDemo/Controllers/CartPageViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/CartPageViewController.swift
@@ -81,7 +81,11 @@ final class CartPageViewController: UIViewController {
     @IBAction func onTapPlaceOrder(_ sender: Any) {
         let vc = storyboard?.instantiateViewController(withIdentifier: "ConfirmationViewController") as! ConfirmationViewController
         vc.orderId = "random_order_id"
-        vc.email = emailTextField.text ?? ""
+        guard let email = emailTextField.text, Utils.isValidEmail(email: email) else {
+            Utils.showAlert(title: "AirRobeDemo", message: "Email is invalid.", vc: self)
+            return
+        }
+        vc.email = email
         navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/AirRobeDemo/AirRobeDemo/Controllers/CartPageViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/CartPageViewController.swift
@@ -18,8 +18,17 @@ final class CartPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIInputViewController.dismissKeyboard))
+        view.addGestureRecognizer(tap)
+
         initCart()
         initMultiOptIn()
+
+        emailTextField.delegate = self
+    }
+
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
     }
 
     private func initCart() {
@@ -81,5 +90,12 @@ final class CartPageViewController: UIViewController {
         vc.orderId = "random_order_id"
         vc.email = emailTextField.text ?? ""
         navigationController?.pushViewController(vc, animated: true)
+    }
+}
+
+extension CartPageViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        view.endEditing(true)
+        return false
     }
 }

--- a/AirRobeDemo/AirRobeDemo/Controllers/CartPageViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/CartPageViewController.swift
@@ -18,17 +18,10 @@ final class CartPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIInputViewController.dismissKeyboard))
-        view.addGestureRecognizer(tap)
-
         initCart()
         initMultiOptIn()
 
         emailTextField.delegate = self
-    }
-
-    @objc func dismissKeyboard() {
-        view.endEditing(true)
     }
 
     private func initCart() {

--- a/AirRobeDemo/AirRobeDemo/Controllers/CategoryViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/CategoryViewController.swift
@@ -14,6 +14,8 @@ final class CategoryViewController: UIViewController {
         return tableView
     }()
 
+    var cartButton: UIBarButtonItem?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.setNavigationBarHidden(false, animated: false)
@@ -25,6 +27,26 @@ final class CategoryViewController: UIViewController {
         tableView.estimatedRowHeight = 120
         tableView.rowHeight = UITableView.automaticDimension
         view.addSubview(tableView)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        addCartButton()
+    }
+
+    private func addCartButton() {
+        let customButton = UIButton(frame: CGRect.init(x: 0, y: 0, width: 30, height: 30))
+        customButton.setImage(UIImage(named:"cart"), for: .normal)
+        customButton.addTarget(self, action: #selector(onTapCart), for: .touchUpInside)
+        cartButton = UIBarButtonItem(customView: customButton)
+        cartButton?.customView?.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        cartButton?.customView?.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        cartButton?.addBadge(number: UserDefaults.standard.cartItems.count)
+        navigationItem.rightBarButtonItem = cartButton
+    }
+
+    @objc func onTapCart(_ sender: Any) {
+        let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "CartPageViewController") as! CartPageViewController
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     override func viewDidLayoutSubviews() {

--- a/AirRobeDemo/AirRobeDemo/Controllers/SubCategoryViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/SubCategoryViewController.swift
@@ -30,10 +30,32 @@ final class SubCategoryViewController: UIViewController {
     }()
     var selectedCategory: CategoryModel?
 
+    var cartButton: UIBarButtonItem?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.setNavigationBarHidden(false, animated: false)
         addViews()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        addCartButton()
+    }
+
+    private func addCartButton() {
+        let customButton = UIButton(frame: CGRect.init(x: 0, y: 0, width: 30, height: 30))
+        customButton.setImage(UIImage(named:"cart"), for: .normal)
+        customButton.addTarget(self, action: #selector(onTapCart), for: .touchUpInside)
+        cartButton = UIBarButtonItem(customView: customButton)
+        cartButton?.customView?.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        cartButton?.customView?.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        cartButton?.addBadge(number: UserDefaults.standard.cartItems.count)
+        navigationItem.rightBarButtonItem = cartButton
+    }
+
+    @objc func onTapCart(_ sender: Any) {
+        let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "CartPageViewController") as! CartPageViewController
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     func addViews() {

--- a/AirRobeDemo/AirRobeDemo/Storyboards/Base.lproj/Main.storyboard
+++ b/AirRobeDemo/AirRobeDemo/Storyboards/Base.lproj/Main.storyboard
@@ -280,6 +280,9 @@
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" textContentType="name"/>
+                                                <connections>
+                                                    <outlet property="delegate" destination="9F5-rY-EnD" id="OwQ-jg-gU0"/>
+                                                </connections>
                                             </textField>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z8k-zo-xef">
                                                 <rect key="frame" x="0.0" y="126.5" width="374" height="20"/>
@@ -306,6 +309,9 @@
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" textContentType="street-address"/>
+                                                <connections>
+                                                    <outlet property="delegate" destination="9F5-rY-EnD" id="sbJ-ib-BTM"/>
+                                                </connections>
                                             </textField>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K1m-Wp-89e">
                                                 <rect key="frame" x="0.0" y="213.5" width="374" height="20"/>
@@ -332,6 +338,9 @@
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" textContentType="tel"/>
+                                                <connections>
+                                                    <outlet property="delegate" destination="9F5-rY-EnD" id="ueH-YL-vhb"/>
+                                                </connections>
                                             </textField>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qPe-xB-nK3">
                                                 <rect key="frame" x="0.0" y="300.5" width="374" height="20"/>
@@ -358,6 +367,9 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="307.5" height="40"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
+                                                        <connections>
+                                                            <outlet property="delegate" destination="9F5-rY-EnD" id="60k-NH-LmF"/>
+                                                        </connections>
                                                     </textField>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="w0F-r6-QCD">
                                                         <rect key="frame" x="307.5" y="0.0" width="66.5" height="40"/>

--- a/AirRobeDemo/AirRobeDemo/Storyboards/Base.lproj/Main.storyboard
+++ b/AirRobeDemo/AirRobeDemo/Storyboards/Base.lproj/Main.storyboard
@@ -241,7 +241,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="iKd-Bd-Mtd">
-                                        <rect key="frame" x="20" y="0.0" width="374" height="1456.5"/>
+                                        <rect key="frame" x="20" y="0.0" width="374" height="1436.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HQ5-bq-Esj">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="20"/>
@@ -397,13 +397,13 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GIi-cS-CHL">
-                                                <rect key="frame" x="0.0" y="410" width="374" height="40"/>
+                                                <rect key="frame" x="0.0" y="410" width="374" height="20"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="qKc-C7-IXj"/>
+                                                    <constraint firstAttribute="height" constant="20" id="qKc-C7-IXj"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ruf-pA-bNX">
-                                                <rect key="frame" x="0.0" y="450" width="374" height="749.5"/>
+                                                <rect key="frame" x="0.0" y="430" width="374" height="749.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="TvY-xX-DC0">
                                                         <rect key="frame" x="20" y="20" width="334" height="709.5"/>
@@ -586,25 +586,25 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pWQ-Or-aPL">
-                                                <rect key="frame" x="0.0" y="1199.5" width="374" height="40"/>
+                                                <rect key="frame" x="0.0" y="1179.5" width="374" height="40"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="YXd-7h-AUl"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email Address (If logged in user)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FSW-zi-AIf">
-                                                <rect key="frame" x="0.0" y="1239.5" width="374" height="17"/>
+                                                <rect key="frame" x="0.0" y="1219.5" width="374" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="59u-83-B5y">
-                                                <rect key="frame" x="0.0" y="1256.5" width="374" height="20"/>
+                                                <rect key="frame" x="0.0" y="1236.5" width="374" height="20"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="ca5-uI-xbG"/>
                                                 </constraints>
                                             </view>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="bezel" placeholder="Your email address" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8JP-HF-Mue">
-                                                <rect key="frame" x="0.0" y="1276.5" width="374" height="40"/>
+                                                <rect key="frame" x="0.0" y="1256.5" width="374" height="40"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="xKo-GJ-H9i"/>
                                                 </constraints>
@@ -612,13 +612,13 @@
                                                 <textInputTraits key="textInputTraits" textContentType="email"/>
                                             </textField>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0x0-Zu-qxX">
-                                                <rect key="frame" x="0.0" y="1316.5" width="374" height="40"/>
+                                                <rect key="frame" x="0.0" y="1296.5" width="374" height="40"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="bJ3-jl-aeJ"/>
                                                 </constraints>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0d5-kH-leC">
-                                                <rect key="frame" x="0.0" y="1356.5" width="374" height="50"/>
+                                                <rect key="frame" x="0.0" y="1336.5" width="374" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="50" id="Sc9-19-J1y"/>
                                                 </constraints>
@@ -631,7 +631,7 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rl7-gk-1hB">
-                                                <rect key="frame" x="0.0" y="1406.5" width="374" height="50"/>
+                                                <rect key="frame" x="0.0" y="1386.5" width="374" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="50" id="MYs-bI-APx"/>
                                                 </constraints>

--- a/AirRobeDemo/AirRobeDemo/Utils/Utils.swift
+++ b/AirRobeDemo/AirRobeDemo/Utils/Utils.swift
@@ -1,0 +1,23 @@
+//
+//  Utils.swift
+//  
+//
+//  Created by King on 7/14/22.
+//
+
+import Foundation
+import UIKit
+
+final class Utils {
+    static func isValidEmail(email: String) -> Bool {
+        let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailPred = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
+        return emailPred.evaluate(with: email)
+    }
+
+    static func showAlert(title: String, message: String, vc: UIViewController) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertController.Style.alert)
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Ok", comment: ""), style: UIAlertAction.Style.default, handler: nil))
+        vc.present(alert, animated: true, completion: nil)
+    }
+}

--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -20,12 +20,12 @@ enum AirRobeStrings {
     static let potentialValue = "Potential value: "
 
     // MARK: - Detailed Description Strings
-    static let detailedDescription = "We’ve partnered with AirRobe to enable you to join the circular fashion movement. Re-sell or rent your purchases on AirRobe’s marketplace – all with one simple click. Together, we can do our part to keep fashion out of landfill. Learn more."
+    static let detailedDescription = "We’ve partnered with AirRobe to enable you to join the circular fashion movement. Re-sell or rent your purchases on AirRobe’s marketplace – all with one simple click. Together, we can do our part to keep fashion out of landfill. \(learnMoreLinkText)"
     static let learnMoreLinkText = "Learn more."
     static let learnMoreLinkForPurpose = URL(string: "https://airrobe.com/")!
 
     // MARK: - Extra Info Strings
-    static let extraInfo = "By opting in you agree to COMPANY NAME’s Privacy Policy and consent for us to share your details with AirRobe."
+    static let extraInfo = "By opting in you agree to \(companyNameText)’s \(extraLinkText) and consent for us to share your details with AirRobe."
     static let extraLinkText = "Privacy Policy"
     static let companyNameText = "COMPANY NAME"
 

--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -29,13 +29,15 @@ enum AirRobeStrings {
 
     // MARK: - Extra Info Strings
 
-    static let extraInfo = "By opting in you agree to THE ICONIC’s Privacy Policy and consent for us to share your details with AirRobe."
+    static let extraInfo = "By opting in you agree to COMPANY NAME’s Privacy Policy and consent for us to share your details with AirRobe."
     static let extraLinkText = "Privacy Policy"
+    static let companyNameText = "COMPANY NAME"
 
     // MARK: - Get Shopping Data Query Strings
     static let GetShoppingDataQuery = """
                 query GetShoppingData ($appId: String) {
                   shop(appId: $appId) {
+                    name
                     categoryMappings(mappedOrExcludedOnly: true) {
                       from
                       to
@@ -68,7 +70,7 @@ enum AirRobeStrings {
     static let learnMoreReady = "READY TO GET STARTED?"
     static let learnMoreToggleOn = "TOGGLE ON!"
     static let learnMoreFindMoreText = "Find out more about AirRobe."
-    static let learnMoreFindMoreLink = URL(string:"https://www.theiconic.com.au/airrobe/")!
+    static let learnMoreFindMoreLink = URL(string: "https://www.theiconic.com.au/airrobe/")!
 
     // MARK: - Order Confirmation View Strings
     static let orderConfirmationTitle = "Your items are in"

--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -22,6 +22,7 @@ enum AirRobeStrings {
     // MARK: - Detailed Description Strings
     static let detailedDescription = "We’ve partnered with AirRobe to enable you to join the circular fashion movement. Re-sell or rent your purchases on AirRobe’s marketplace – all with one simple click. Together, we can do our part to keep fashion out of landfill. Learn more."
     static let learnMoreLinkText = "Learn more."
+    static let learnMoreLinkForPurpose = URL(string: "https://airrobe.com/")!
 
     // MARK: - Extra Info Strings
     static let extraInfo = "By opting in you agree to COMPANY NAME’s Privacy Policy and consent for us to share your details with AirRobe."

--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -9,26 +9,21 @@ import Foundation
 
 enum AirRobeStrings {
     // MARK: - Title Strings
-
     static let added = "Added To"
     static let add = "Add To"
 
     // MARK: - Description Strings
-
     static let description = "Wear now, re-sell later."
     static let descriptionCutOffText = "Re-sell later."
 
     // MARK: - Potential Value Strings
-
     static let potentialValue = "Potential value: "
 
     // MARK: - Detailed Description Strings
-
     static let detailedDescription = "We’ve partnered with AirRobe to enable you to join the circular fashion movement. Re-sell or rent your purchases on AirRobe’s marketplace – all with one simple click. Together, we can do our part to keep fashion out of landfill. Learn more."
     static let learnMoreLinkText = "Learn more."
 
     // MARK: - Extra Info Strings
-
     static let extraInfo = "By opting in you agree to COMPANY NAME’s Privacy Policy and consent for us to share your details with AirRobe."
     static let extraLinkText = "Privacy Policy"
     static let companyNameText = "COMPANY NAME"
@@ -38,6 +33,8 @@ enum AirRobeStrings {
                 query GetShoppingData ($appId: String) {
                   shop(appId: $appId) {
                     name
+                    privacyUrl
+                    popupFindOutMoreUrl
                     categoryMappings(mappedOrExcludedOnly: true) {
                       from
                       to
@@ -70,7 +67,6 @@ enum AirRobeStrings {
     static let learnMoreReady = "READY TO GET STARTED?"
     static let learnMoreToggleOn = "TOGGLE ON!"
     static let learnMoreFindMoreText = "Find out more about AirRobe."
-    static let learnMoreFindMoreLink = URL(string: "https://www.theiconic.com.au/airrobe/")!
 
     // MARK: - Order Confirmation View Strings
     static let orderConfirmationTitle = "Your items are in"

--- a/Sources/AirRobeWidget/Config/AirRobeWidgetConfig.swift
+++ b/Sources/AirRobeWidget/Config/AirRobeWidgetConfig.swift
@@ -18,25 +18,19 @@ public struct AirRobeWidgetConfig {
     /// AirRobe Widget App ID from https://connector.airrobe.com
     var appId: String = ""
 
-    /// Privacy Policy link for Iconic
-    var privacyPolicyURL: String = ""
-
     /// AirRobe Widget Select Mode whether production or sandbox
     /// default value = .production
     var mode: Mode = .production
 
-    /// set AirRobeWidget AppId and SecretKey
+    /// set AirRobeWidget AppId
     /// - Parameters:
     ///   - appId: App ID from https://connector.airrobe.com
-    ///   - privacyPolicyLink: Privacy Policy link for Iconic
     ///   - mode: Selector for production or sandbox mode
     public init(
         appId: String,
-        privacyPolicyURL: String,
         mode: Mode = .production
     ) {
         self.appId = appId
-        self.privacyPolicyURL = privacyPolicyURL
         self.mode = mode
     }
 

--- a/Sources/AirRobeWidget/Config/AirRobeWidgetInfo.swift
+++ b/Sources/AirRobeWidget/Config/AirRobeWidgetInfo.swift
@@ -22,7 +22,7 @@ public struct AirRobeWidgetInfo {
     fileprivate(set) var version: String
 
     /// Version of Widget being used
-    static let version = "1.0.9"
+    static let version = "1.1.0"
 
     #if os(iOS)
     /// Platform that is being used: ios, macos, unknown

--- a/Sources/AirRobeWidget/Service/AirRobeApiService.swift
+++ b/Sources/AirRobeWidget/Service/AirRobeApiService.swift
@@ -13,10 +13,10 @@ final class AirRobeApiService: AirRobeNetworkClient {
     let session: URLSession
     let additionalRequestBodyParams: [String: String]
 
-    /// AirRobWidget PriceEngine Api Service Initialization
+    /// AirRobWidget Api Service Initialization
     /// - Parameters:
     ///   - configuration: URLSessionConfiguration here - most likely to add the app & system information to the URLRequest header
-    ///   - additionalRequestBodyParams: In case we need to have something like Device ID, App version, Country or etc.
+    ///   - additionalRequestBodyParams: In case we need to have something like Device ID, App version or etc.
     init(configuration: URLSessionConfiguration? = nil,
          additionalRequestBodyParams: [String: String] = [:]) {
 

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
@@ -20,6 +20,8 @@ struct AirRobeShoppingDataModel: Codable {
 // MARK: - ShopModel
 struct AirRobeShopModel: Codable {
     let name: String
+    let privacyUrl: String
+    let popupFindOutMoreUrl: String
     let categoryMappings: [AirRobeCategoryMapping]
     let minimumPriceThresholds: [AirRobeMinPriceThresholds]
 }

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
@@ -19,6 +19,7 @@ struct AirRobeShoppingDataModel: Codable {
 
 // MARK: - ShopModel
 struct AirRobeShopModel: Codable {
+    let name: String
     let categoryMappings: [AirRobeCategoryMapping]
     let minimumPriceThresholds: [AirRobeMinPriceThresholds]
 }

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
@@ -20,7 +20,7 @@ struct AirRobeShoppingDataModel: Codable {
 // MARK: - ShopModel
 struct AirRobeShopModel: Codable {
     let name: String
-    let privacyUrl: String
+    let privacyUrl: String?
     let popupFindOutMoreUrl: String
     let categoryMappings: [AirRobeCategoryMapping]
     let minimumPriceThresholds: [AirRobeMinPriceThresholds]

--- a/Sources/AirRobeWidget/Views/LearnMoreAlertViewController/AirRobeLearnMoreAlertViewController.storyboard
+++ b/Sources/AirRobeWidget/Views/LearnMoreAlertViewController/AirRobeLearnMoreAlertViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -289,11 +289,11 @@
                                             </stackView>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="top" secondItem="BuI-f9-1fE" secondAttribute="top" id="PcA-dX-KnS"/>
+                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="top" secondItem="ncs-I2-dAj" secondAttribute="top" id="PcA-dX-KnS"/>
                                             <constraint firstAttribute="height" constant="530" id="Q83-Dn-7aG"/>
-                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="bottom" secondItem="BuI-f9-1fE" secondAttribute="bottom" id="qSz-Pw-TCp"/>
-                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="trailing" secondItem="BuI-f9-1fE" secondAttribute="trailing" constant="20" id="xzT-MM-Fg0"/>
-                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="leading" secondItem="BuI-f9-1fE" secondAttribute="leading" constant="20" id="ziL-3T-rWD"/>
+                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="bottom" secondItem="ncs-I2-dAj" secondAttribute="bottom" id="qSz-Pw-TCp"/>
+                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="trailing" secondItem="ncs-I2-dAj" secondAttribute="trailing" id="xzT-MM-Fg0"/>
+                                            <constraint firstItem="cCd-q6-Axv" firstAttribute="leading" secondItem="ncs-I2-dAj" secondAttribute="leading" id="ziL-3T-rWD"/>
                                         </constraints>
                                         <viewLayoutGuide key="contentLayoutGuide" id="ncs-I2-dAj"/>
                                         <viewLayoutGuide key="frameLayoutGuide" id="8Kg-46-yL8"/>
@@ -312,23 +312,8 @@
                                     <constraint firstAttribute="trailing" secondItem="teX-H0-ZHK" secondAttribute="trailing" id="eDB-dy-Qkx"/>
                                     <constraint firstAttribute="bottom" secondItem="BuI-f9-1fE" secondAttribute="bottom" constant="20" id="hOa-jG-izV"/>
                                     <constraint firstItem="5xt-oI-Dw1" firstAttribute="centerX" secondItem="EyT-lf-6qW" secondAttribute="centerX" id="sse-Z2-oX5"/>
-                                    <constraint firstAttribute="trailing" secondItem="cCd-q6-Axv" secondAttribute="trailing" constant="20" id="tCQ-pt-Dm8"/>
                                     <constraint firstAttribute="trailing" secondItem="ELr-2r-adY" secondAttribute="trailing" constant="12" id="xja-cZ-ccz"/>
                                 </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="startColor">
-                                        <color key="value" systemColor="systemBackgroundColor"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="endColor">
-                                        <color key="value" systemColor="systemBackgroundColor"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="shadowColor">
-                                        <color key="value" systemColor="opaqueSeparatorColor"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="20"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
@@ -379,9 +364,6 @@
         <image name="smileEmojiIcon" width="16" height="16"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="opaqueSeparatorColor">
-            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Sources/AirRobeWidget/Views/LearnMoreAlertViewController/AirRobeLearnMoreAlertViewController.swift
+++ b/Sources/AirRobeWidget/Views/LearnMoreAlertViewController/AirRobeLearnMoreAlertViewController.swift
@@ -53,10 +53,16 @@ final class AirRobeLearnMoreAlertViewController: UIViewController, StoryboardBas
         toggleOnLabel.text = AirRobeStrings.learnMoreToggleOn
         toggleOnLabel.textColor = AirRobeTextColor
         findMoreLabel.hyperlinkAttributes = [.foregroundColor: AirRobeLinkTextColor]
+        guard let learnMoreFindMoreLink = URL(string: AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.data.shop.popupFindOutMoreUrl ?? "") else {
+            #if DEBUG
+            print("Popup find out more url is not valid.")
+            #endif
+            return
+        }
         findMoreLabel.setLinkText(
             orgText: AirRobeStrings.learnMoreFindMoreText,
             linkText: AirRobeStrings.learnMoreFindMoreText,
-            link: AirRobeStrings.learnMoreFindMoreLink,
+            link: learnMoreFindMoreLink,
             tapHandler: onTapFindMoreLink)
         optSwitch.isOn = UserDefaults.standard.OptedIn
         optSwitch.onTintColor = AirRobeSwitchColor

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -219,7 +219,7 @@ private extension AirRobeOptInView {
             .sink(receiveCompletion: {
                 print($0)
             }, receiveValue: { [weak self] (shoppingDataModel) in
-                guard let self = self, shoppingDataModel != nil else {
+                guard let self = self, shoppingDataModel != nil, !self.viewModel.alreadyInitialized else {
                     return
                 }
                 switch self.viewType {

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -102,8 +102,9 @@ final class AirRobeOptInView: UIView, NibLoadable {
             tapHandler: onTapLearnMore)
         detailedDescriptionLabel.isHidden = true
         margin.isHidden = true
+        let extraInfo = AirRobeStrings.extraInfo.replacingOccurrences(of: AirRobeStrings.companyNameText, with: AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.data.shop.name ?? "")
         extraInfoLabel.setLinkText(
-            orgText: AirRobeStrings.extraInfo,
+            orgText: extraInfo,
             linkText: AirRobeStrings.extraLinkText,
             link: privacyLink,
             tapHandler: onTapExtraInfoLink)

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -25,6 +25,8 @@ final class AirRobeOptInView: UIView, NibLoadable {
     @IBOutlet weak var detailedDescriptionLabel: AirRobeHyperlinkLabel!
     @IBOutlet weak var subTitleContainer: UIStackView!
 
+    private let EXTRA_PADDING_FOR_DESCRIPTION_LABEL_MAX_WIDTH = 20.0
+
     enum ExpandState {
         case opened
         case closed
@@ -58,18 +60,22 @@ final class AirRobeOptInView: UIView, NibLoadable {
     }
 
     override func layoutSubviews() {
-        let maxWidth = subTitleContainer.bounds.width - potentialValueLabel.bounds.width - potentialValueLoading.bounds.width
+        let maxWidth = usableHorizontalSpace()
         if descriptionValueLabelMaxWidth != maxWidth {
             descriptionValueLabelMaxWidth = maxWidth
             guard let value = descriptionLabel.text, value.isEmpty || value == AirRobeStrings.description else {
                 return
             }
-            if ((AirRobeStrings.description).width(withFont: descriptionLabel.font).width + 20) > descriptionValueLabelMaxWidth {
+            if ((AirRobeStrings.description).width(withFont: descriptionLabel.font).width + EXTRA_PADDING_FOR_DESCRIPTION_LABEL_MAX_WIDTH) > descriptionValueLabelMaxWidth {
                 descriptionLabel.text = AirRobeStrings.descriptionCutOffText
             } else {
                 descriptionLabel.text = AirRobeStrings.description
             }
         }
+    }
+
+    private func usableHorizontalSpace() -> CGFloat {
+        return subTitleContainer.bounds.width - potentialValueLabel.bounds.width - potentialValueLoading.bounds.width
     }
 
     private func commonInit() {
@@ -283,7 +289,7 @@ private extension AirRobeOptInView {
                 DispatchQueue.main.async {
                     self.potentialValueLoading.stopAnimating()
                     self.potentialValueLabel.text = AirRobeStrings.potentialValue + "$" + price
-                    if ((AirRobeStrings.description).width(withFont: self.descriptionLabel.font).width + 20) > self.descriptionValueLabelMaxWidth {
+                    if ((AirRobeStrings.description).width(withFont: self.descriptionLabel.font).width + self.EXTRA_PADDING_FOR_DESCRIPTION_LABEL_MAX_WIDTH) > self.descriptionValueLabelMaxWidth {
                         self.descriptionLabel.text = AirRobeStrings.descriptionCutOffText
                         return
                     }

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -14,7 +14,7 @@ final class AirRobeOptInView: UIView, NibLoadable {
     @IBOutlet weak var widgetStackView: UIStackView!
     @IBOutlet weak var mainContainerView: UIView!
     @IBOutlet weak var mainContainerExpandButton: UIButton!
-    @IBOutlet weak var margin: UIView!
+    @IBOutlet weak var extraInfoContainer: UIView!
     @IBOutlet weak var extraInfoLabel: AirRobeHyperlinkLabel!
     @IBOutlet weak var addToAirRobeSwitch: UISwitch!
     @IBOutlet weak var titleLabel: UILabel!
@@ -83,25 +83,28 @@ final class AirRobeOptInView: UIView, NibLoadable {
         potentialValueLoading.hidesWhenStopped = true
         potentialValueLoading.startAnimating()
 
-        guard let privacyLink = URL(string: AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.data.shop.privacyUrl ?? "") else {
-            #if DEBUG
-            print("Privacy policy url is not valid.")
-            #endif
-            return
-        }
         detailedDescriptionLabel.setLinkText(
             orgText: AirRobeStrings.detailedDescription,
             linkText: AirRobeStrings.learnMoreLinkText,
-            link: privacyLink,
+            link: AirRobeStrings.learnMoreLinkForPurpose,
             tapHandler: onTapLearnMore)
         detailedDescriptionLabel.isHidden = true
-        margin.isHidden = true
-        let extraInfo = AirRobeStrings.extraInfo.replacingOccurrences(of: AirRobeStrings.companyNameText, with: AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.data.shop.name ?? "")
-        extraInfoLabel.setLinkText(
-            orgText: extraInfo,
-            linkText: AirRobeStrings.extraLinkText,
-            link: privacyLink,
-            tapHandler: onTapExtraInfoLink)
+
+        if let privacyLink = URL(string: AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.data.shop.privacyUrl ?? "") {
+            extraInfoContainer.isHidden = false
+            let extraInfo = AirRobeStrings.extraInfo.replacingOccurrences(of: AirRobeStrings.companyNameText, with: AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.data.shop.name ?? "")
+            extraInfoLabel.setLinkText(
+                orgText: extraInfo,
+                linkText: AirRobeStrings.extraLinkText,
+                link: privacyLink,
+                tapHandler: onTapExtraInfoLink)
+        } else {
+            extraInfoContainer.isHidden = true
+            #if DEBUG
+            print("Privacy policy url is not valid.")
+            #endif
+        }
+
         addToAirRobeSwitch.isOn = UserDefaults.standard.OptedIn
         arrowImageView.image = arrowImageView.image?.withRenderingMode(.alwaysTemplate)
         setupBindings()
@@ -179,7 +182,6 @@ final class AirRobeOptInView: UIView, NibLoadable {
         })
         tableView?.beginUpdates()
         detailedDescriptionLabel.isHidden.toggle()
-        margin.isHidden.toggle()
         tableView?.endUpdates()
     }
 }

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -83,13 +83,7 @@ final class AirRobeOptInView: UIView, NibLoadable {
         potentialValueLoading.hidesWhenStopped = true
         potentialValueLoading.startAnimating()
 
-        guard let appConfig = configuration else {
-            #if DEBUG
-            print("Widget is not yet configured.")
-            #endif
-            return
-        }
-        guard let privacyLink = URL(string: appConfig.privacyPolicyURL) else {
+        guard let privacyLink = URL(string: AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.data.shop.privacyUrl ?? "") else {
             #if DEBUG
             print("Privacy policy url is not valid.")
             #endif

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -219,7 +219,7 @@ private extension AirRobeOptInView {
             .sink(receiveCompletion: {
                 print($0)
             }, receiveValue: { [weak self] (shoppingDataModel) in
-                guard let self = self, shoppingDataModel != nil, !self.viewModel.alreadyInitialized else {
+                guard let self = self, shoppingDataModel != nil else {
                     return
                 }
                 switch self.viewType {

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -13,7 +13,7 @@ import Combine
 final class AirRobeOptInView: UIView, NibLoadable {
     @IBOutlet weak var widgetStackView: UIStackView!
     @IBOutlet weak var mainContainerView: UIView!
-    @IBOutlet weak var mainContainerExpandButton: UIButton!
+    @IBOutlet weak var topContentContainer: UIStackView!
     @IBOutlet weak var extraInfoContainer: UIView!
     @IBOutlet weak var extraInfoLabel: AirRobeHyperlinkLabel!
     @IBOutlet weak var addToAirRobeSwitch: UISwitch!
@@ -75,6 +75,13 @@ final class AirRobeOptInView: UIView, NibLoadable {
     private func commonInit() {
         // Widget Border Style
         mainContainerView.addBorder(color: AirRobeBorderColor.cgColor, cornerRadius: 0)
+
+        let tapOnArrowImage = UITapGestureRecognizer(target: self, action:  #selector(onTapArrow))
+        arrowImageView.isUserInteractionEnabled = true
+        arrowImageView.addGestureRecognizer(tapOnArrowImage)
+
+        let tapOnTopContentContainer = UITapGestureRecognizer(target: self, action:  #selector(onTapArrow))
+        topContentContainer.addGestureRecognizer(tapOnTopContentContainer)
 
         // Initializing Static Texts & Links
         titleLabel.text = UserDefaults.standard.OptedIn ? AirRobeStrings.added : AirRobeStrings.add
@@ -153,7 +160,11 @@ final class AirRobeOptInView: UIView, NibLoadable {
         }
     }
 
-    @IBAction func onTapExpand(_ sender: Any) {
+    @objc func onTapArrow(_ sender: UITapGestureRecognizer) {
+        onExpand()
+    }
+
+    func onExpand() {
         let degree: CGFloat = {
             switch expandType {
             case .opened:

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -58,13 +58,13 @@ final class AirRobeOptInView: UIView, NibLoadable {
     }
 
     override func layoutSubviews() {
-        let maxWidth = subTitleContainer.bounds.width - potentialValueLabel.bounds.width - 10 - potentialValueLoading.bounds.width
-        if descriptionValueLabelMaxWidth != maxWidth && viewType == .optIn {
+        let maxWidth = subTitleContainer.bounds.width - potentialValueLabel.bounds.width - potentialValueLoading.bounds.width
+        if descriptionValueLabelMaxWidth != maxWidth {
             descriptionValueLabelMaxWidth = maxWidth
             guard let value = descriptionLabel.text, value.isEmpty || value == AirRobeStrings.description else {
                 return
             }
-            if (AirRobeStrings.description).width(withFont: descriptionLabel.font).width > descriptionValueLabelMaxWidth {
+            if ((AirRobeStrings.description).width(withFont: descriptionLabel.font).width + 20) > descriptionValueLabelMaxWidth {
                 descriptionLabel.text = AirRobeStrings.descriptionCutOffText
             } else {
                 descriptionLabel.text = AirRobeStrings.description
@@ -283,7 +283,7 @@ private extension AirRobeOptInView {
                 DispatchQueue.main.async {
                     self.potentialValueLoading.stopAnimating()
                     self.potentialValueLabel.text = AirRobeStrings.potentialValue + "$" + price
-                    if ((AirRobeStrings.description).width(withFont: self.descriptionLabel.font).width + 15) < self.descriptionValueLabelMaxWidth {
+                    if ((AirRobeStrings.description).width(withFont: self.descriptionLabel.font).width + 20) > self.descriptionValueLabelMaxWidth {
                         self.descriptionLabel.text = AirRobeStrings.descriptionCutOffText
                         return
                     }

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -191,9 +191,11 @@ final class AirRobeOptInView: UIView, NibLoadable {
         UIView.animate(withDuration: 0.1, delay: 0.0, options: .curveLinear, animations: { [weak self] in
             self?.arrowImageView.layer.transform = CATransform3DMakeRotation(CGFloat(Double.pi), degree, 0.0, 0.0)
         })
-        tableView?.beginUpdates()
-        detailedDescriptionLabel.isHidden.toggle()
-        tableView?.endUpdates()
+        AirRobeOptInView.performWithoutAnimation {
+            tableView?.beginUpdates()
+            detailedDescriptionLabel.isHidden.toggle()
+            tableView?.endUpdates()
+        }
     }
 }
 

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
@@ -20,10 +20,10 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="swg-ok-dY1">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="103"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZ6-M6-d25">
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZ6-M6-d25">
                                     <rect key="frame" x="10" y="10" width="394" height="83"/>
                                     <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="WEk-A1-pCz">
+                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="WEk-A1-pCz">
                                             <rect key="frame" x="0.0" y="0.0" width="394" height="73"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0fP-yw-WwF">
@@ -35,7 +35,7 @@
                                                         <action selector="onTapSwitch:" destination="iN0-l3-epB" eventType="valueChanged" id="0bY-DC-bfM"/>
                                                     </connections>
                                                 </switch>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TEX-9a-wru">
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TEX-9a-wru">
                                                     <rect key="frame" x="60" y="0.0" width="308" height="73"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v6L-SC-vLf">
@@ -150,10 +150,10 @@
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="diC-iE-Oqe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="5zT-jJ-dpi"/>
-                <constraint firstItem="diC-iE-Oqe" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="cxx-yp-JiP"/>
-                <constraint firstAttribute="bottom" secondItem="diC-iE-Oqe" secondAttribute="bottom" id="sgs-6a-Phi"/>
-                <constraint firstAttribute="trailing" secondItem="diC-iE-Oqe" secondAttribute="trailing" id="xHW-Yx-Npq"/>
+                <constraint firstItem="diC-iE-Oqe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" priority="999" id="5zT-jJ-dpi"/>
+                <constraint firstItem="diC-iE-Oqe" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" priority="999" id="cxx-yp-JiP"/>
+                <constraint firstAttribute="bottom" secondItem="diC-iE-Oqe" secondAttribute="bottom" priority="999" id="sgs-6a-Phi"/>
+                <constraint firstAttribute="trailing" secondItem="diC-iE-Oqe" secondAttribute="trailing" priority="999" id="xHW-Yx-Npq"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,169 +11,176 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="AirRobeOptInView" customModule="AirRobeWidget">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="swg-ok-dY1">
-                    <rect key="frame" x="0.0" y="44" width="414" height="798"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="diC-iE-Oqe">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="vZ6-M6-d25">
-                            <rect key="frame" x="10" y="10" width="394" height="778"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="swg-ok-dY1">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="290"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P3t-bM-4hC">
-                                    <rect key="frame" x="0.0" y="0.0" width="394" height="40"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZ6-M6-d25">
+                                    <rect key="frame" x="10" y="10" width="394" height="270"/>
                                     <subviews>
-                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0fP-yw-WwF">
-                                            <rect key="frame" x="0.0" y="4.5" width="51" height="31"/>
-                                            <connections>
-                                                <action selector="onTapSwitch:" destination="iN0-l3-epB" eventType="valueChanged" id="0bY-DC-bfM"/>
-                                            </connections>
-                                        </switch>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FkA-oy-yGJ">
-                                            <rect key="frame" x="59" y="12" width="0.0" height="0.0"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                            <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P3t-bM-4hC">
+                                            <rect key="frame" x="0.0" y="0.0" width="394" height="40"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0fP-yw-WwF">
+                                                    <rect key="frame" x="0.0" y="4.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="onTapSwitch:" destination="iN0-l3-epB" eventType="valueChanged" id="0bY-DC-bfM"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FkA-oy-yGJ">
+                                                    <rect key="frame" x="59" y="12" width="0.0" height="0.0"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="airRobeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="fCW-So-70G">
+                                                    <rect key="frame" x="69" y="0.0" width="90" height="18"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="90" id="JU6-dk-PHI"/>
+                                                        <constraint firstAttribute="height" constant="18" id="WQJ-0i-qvO"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
+                                                    <rect key="frame" x="59" y="23" width="309" height="17"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
+                                                            <rect key="frame" x="0.0" y="0.0" width="82.5" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u7d-E3-PXv">
+                                                            <rect key="frame" x="82.5" y="0.0" width="5" height="17"/>
+                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="5" id="4Rl-eR-dAp"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
+                                                            <rect key="frame" x="87.5" y="0.0" width="184.5" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                            <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dVN-53-Wge">
+                                                            <rect key="frame" x="272" y="0.0" width="5" height="17"/>
+                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="5" id="ihS-fc-3Pn"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="iiN-y3-ZaS">
+                                                            <rect key="frame" x="277" y="0.0" width="20" height="17"/>
+                                                        </activityIndicatorView>
+                                                        <view contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="dPt-N0-3cH">
+                                                            <rect key="frame" x="297" y="0.0" width="12" height="17"/>
+                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        </view>
+                                                    </subviews>
+                                                </stackView>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowDown" translatesAutoresizingMaskIntoConstraints="NO" id="Hpz-Z1-uaW">
+                                                    <rect key="frame" x="378" y="12" width="16" height="16"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="16" id="Fle-Ry-ean"/>
+                                                        <constraint firstAttribute="height" constant="16" id="SQQ-Vc-rwb"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fvc-fX-KYx">
+                                                    <rect key="frame" x="59" y="0.0" width="335" height="40"/>
+                                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                    <connections>
+                                                        <action selector="onTapExpand:" destination="iN0-l3-epB" eventType="touchUpInside" id="iQd-yu-g7K"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="40" id="192-vZ-i2i"/>
+                                                <constraint firstItem="9Tx-ha-3VQ" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="1Gj-AK-5kU"/>
+                                                <constraint firstItem="fCW-So-70G" firstAttribute="top" secondItem="P3t-bM-4hC" secondAttribute="top" id="GYd-GS-Kbw"/>
+                                                <constraint firstItem="FkA-oy-yGJ" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="N2M-7M-FYP"/>
+                                                <constraint firstItem="0fP-yw-WwF" firstAttribute="leading" secondItem="P3t-bM-4hC" secondAttribute="leading" id="Tqf-2p-dg0"/>
+                                                <constraint firstItem="fCW-So-70G" firstAttribute="leading" secondItem="FkA-oy-yGJ" secondAttribute="trailing" constant="10" id="U5C-wu-ejW"/>
+                                                <constraint firstItem="Hpz-Z1-uaW" firstAttribute="centerY" secondItem="P3t-bM-4hC" secondAttribute="centerY" id="VU7-KX-keK"/>
+                                                <constraint firstAttribute="trailing" secondItem="Fvc-fX-KYx" secondAttribute="trailing" id="aUl-4m-myX"/>
+                                                <constraint firstAttribute="trailing" secondItem="Hpz-Z1-uaW" secondAttribute="trailing" id="dkB-Ys-ZRA"/>
+                                                <constraint firstItem="0fP-yw-WwF" firstAttribute="centerY" secondItem="P3t-bM-4hC" secondAttribute="centerY" id="fGw-rQ-lEI"/>
+                                                <constraint firstAttribute="bottom" secondItem="9Tx-ha-3VQ" secondAttribute="bottom" id="h6J-cB-aXO"/>
+                                                <constraint firstAttribute="bottom" secondItem="Fvc-fX-KYx" secondAttribute="bottom" id="ivf-AI-AbE"/>
+                                                <constraint firstItem="Fvc-fX-KYx" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="jrG-Zs-Al7"/>
+                                                <constraint firstItem="Fvc-fX-KYx" firstAttribute="top" secondItem="P3t-bM-4hC" secondAttribute="top" id="khE-t4-PvJ"/>
+                                                <constraint firstItem="FkA-oy-yGJ" firstAttribute="centerY" secondItem="fCW-So-70G" secondAttribute="centerY" constant="3" id="sqL-06-dpx"/>
+                                                <constraint firstItem="9Tx-ha-3VQ" firstAttribute="top" secondItem="fCW-So-70G" secondAttribute="bottom" constant="5" id="vz1-yD-SUm"/>
+                                                <constraint firstItem="Hpz-Z1-uaW" firstAttribute="leading" secondItem="9Tx-ha-3VQ" secondAttribute="trailing" constant="10" id="wmy-19-Nhz"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-u6-Ipi" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
+                                            <rect key="frame" x="0.0" y="270" width="394" height="0.0"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="airRobeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="fCW-So-70G">
-                                            <rect key="frame" x="69" y="0.0" width="90" height="18"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="90" id="JU6-dk-PHI"/>
-                                                <constraint firstAttribute="height" constant="18" id="WQJ-0i-qvO"/>
-                                            </constraints>
-                                        </imageView>
-                                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
-                                            <rect key="frame" x="59" y="23" width="309" height="17"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
-                                                    <rect key="frame" x="0.0" y="0.0" width="82.5" height="17"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u7d-E3-PXv">
-                                                    <rect key="frame" x="82.5" y="0.0" width="5" height="17"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="5" id="4Rl-eR-dAp"/>
-                                                    </constraints>
-                                                </view>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
-                                                    <rect key="frame" x="87.5" y="0.0" width="184.5" height="17"/>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
-                                                    <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dVN-53-Wge">
-                                                    <rect key="frame" x="272" y="0.0" width="5" height="17"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="5" id="ihS-fc-3Pn"/>
-                                                    </constraints>
-                                                </view>
-                                                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="iiN-y3-ZaS">
-                                                    <rect key="frame" x="277" y="0.0" width="20" height="17"/>
-                                                </activityIndicatorView>
-                                                <view contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="dPt-N0-3cH">
-                                                    <rect key="frame" x="297" y="0.0" width="12" height="17"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                </view>
-                                            </subviews>
-                                        </stackView>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowDown" translatesAutoresizingMaskIntoConstraints="NO" id="Hpz-Z1-uaW">
-                                            <rect key="frame" x="378" y="12" width="16" height="16"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="16" id="Fle-Ry-ean"/>
-                                                <constraint firstAttribute="height" constant="16" id="SQQ-Vc-rwb"/>
-                                            </constraints>
-                                        </imageView>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fvc-fX-KYx">
-                                            <rect key="frame" x="59" y="0.0" width="335" height="40"/>
-                                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                            <connections>
-                                                <action selector="onTapExpand:" destination="iN0-l3-epB" eventType="touchUpInside" id="iQd-yu-g7K"/>
-                                            </connections>
-                                        </button>
                                     </subviews>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="40" id="192-vZ-i2i"/>
-                                        <constraint firstItem="9Tx-ha-3VQ" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="1Gj-AK-5kU"/>
-                                        <constraint firstItem="fCW-So-70G" firstAttribute="top" secondItem="P3t-bM-4hC" secondAttribute="top" id="GYd-GS-Kbw"/>
-                                        <constraint firstItem="FkA-oy-yGJ" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="N2M-7M-FYP"/>
-                                        <constraint firstItem="0fP-yw-WwF" firstAttribute="leading" secondItem="P3t-bM-4hC" secondAttribute="leading" id="Tqf-2p-dg0"/>
-                                        <constraint firstItem="fCW-So-70G" firstAttribute="leading" secondItem="FkA-oy-yGJ" secondAttribute="trailing" constant="10" id="U5C-wu-ejW"/>
-                                        <constraint firstItem="Hpz-Z1-uaW" firstAttribute="centerY" secondItem="P3t-bM-4hC" secondAttribute="centerY" id="VU7-KX-keK"/>
-                                        <constraint firstAttribute="trailing" secondItem="Fvc-fX-KYx" secondAttribute="trailing" id="aUl-4m-myX"/>
-                                        <constraint firstAttribute="trailing" secondItem="Hpz-Z1-uaW" secondAttribute="trailing" id="dkB-Ys-ZRA"/>
-                                        <constraint firstItem="0fP-yw-WwF" firstAttribute="centerY" secondItem="P3t-bM-4hC" secondAttribute="centerY" id="fGw-rQ-lEI"/>
-                                        <constraint firstAttribute="bottom" secondItem="9Tx-ha-3VQ" secondAttribute="bottom" id="h6J-cB-aXO"/>
-                                        <constraint firstAttribute="bottom" secondItem="Fvc-fX-KYx" secondAttribute="bottom" id="ivf-AI-AbE"/>
-                                        <constraint firstItem="Fvc-fX-KYx" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="jrG-Zs-Al7"/>
-                                        <constraint firstItem="Fvc-fX-KYx" firstAttribute="top" secondItem="P3t-bM-4hC" secondAttribute="top" id="khE-t4-PvJ"/>
-                                        <constraint firstItem="FkA-oy-yGJ" firstAttribute="centerY" secondItem="fCW-So-70G" secondAttribute="centerY" constant="3" id="sqL-06-dpx"/>
-                                        <constraint firstItem="9Tx-ha-3VQ" firstAttribute="top" secondItem="fCW-So-70G" secondAttribute="bottom" constant="5" id="vz1-yD-SUm"/>
-                                        <constraint firstItem="Hpz-Z1-uaW" firstAttribute="leading" secondItem="9Tx-ha-3VQ" secondAttribute="trailing" constant="10" id="wmy-19-Nhz"/>
-                                    </constraints>
-                                </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6RC-xd-TY7">
-                                    <rect key="frame" x="0.0" y="40" width="394" height="10"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="10" id="VcM-4E-Mi1"/>
-                                    </constraints>
-                                </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-u6-Ipi" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
-                                    <rect key="frame" x="0.0" y="50" width="394" height="728"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="vZ6-M6-d25" firstAttribute="leading" secondItem="swg-ok-dY1" secondAttribute="leading" constant="10" id="Xki-FE-fen"/>
+                                <constraint firstAttribute="bottom" secondItem="vZ6-M6-d25" secondAttribute="bottom" constant="10" id="dgF-sD-dzd"/>
+                                <constraint firstItem="vZ6-M6-d25" firstAttribute="top" secondItem="swg-ok-dY1" secondAttribute="top" constant="10" id="fJ5-iA-AbU"/>
+                                <constraint firstAttribute="trailing" secondItem="vZ6-M6-d25" secondAttribute="trailing" constant="10" id="oQK-p7-GCF"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A4u-oB-nyq">
+                            <rect key="frame" x="0.0" y="300" width="414" height="0.0"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dp7-jD-L3u" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
+                                    <rect key="frame" x="10" y="0.0" width="394" height="0.0"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                     <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
-                        </stackView>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="dp7-jD-L3u" secondAttribute="trailing" constant="10" id="5e2-C8-Liz"/>
+                                <constraint firstItem="dp7-jD-L3u" firstAttribute="leading" secondItem="A4u-oB-nyq" secondAttribute="leading" constant="10" id="C2r-ue-m9o"/>
+                                <constraint firstItem="dp7-jD-L3u" firstAttribute="top" secondItem="A4u-oB-nyq" secondAttribute="top" id="bgZ-Rc-ClW"/>
+                                <constraint firstAttribute="bottom" secondItem="dp7-jD-L3u" secondAttribute="bottom" id="kqM-Sf-Cve"/>
+                            </constraints>
+                        </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <constraints>
-                        <constraint firstItem="vZ6-M6-d25" firstAttribute="leading" secondItem="swg-ok-dY1" secondAttribute="leading" constant="10" id="Xki-FE-fen"/>
-                        <constraint firstAttribute="bottom" secondItem="vZ6-M6-d25" secondAttribute="bottom" constant="10" id="dgF-sD-dzd"/>
-                        <constraint firstItem="vZ6-M6-d25" firstAttribute="top" secondItem="swg-ok-dY1" secondAttribute="top" constant="10" id="fJ5-iA-AbU"/>
-                        <constraint firstAttribute="trailing" secondItem="vZ6-M6-d25" secondAttribute="trailing" constant="10" id="oQK-p7-GCF"/>
-                    </constraints>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dp7-jD-L3u" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
-                    <rect key="frame" x="10" y="852" width="394" height="0.0"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                    <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                </stackView>
             </subviews>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="swg-ok-dY1" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="6g5-6A-DYA"/>
-                <constraint firstItem="dp7-jD-L3u" firstAttribute="top" secondItem="swg-ok-dY1" secondAttribute="bottom" constant="10" id="NAT-mQ-l5s"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="dp7-jD-L3u" secondAttribute="trailing" constant="10" id="O4P-xq-YOt"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="dp7-jD-L3u" secondAttribute="bottom" constant="10" id="OBW-es-qtM"/>
-                <constraint firstAttribute="trailing" secondItem="swg-ok-dY1" secondAttribute="trailing" id="aVK-tZ-THu"/>
-                <constraint firstItem="dp7-jD-L3u" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="10" id="vM0-mG-2lA"/>
-                <constraint firstItem="swg-ok-dY1" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="ykp-al-5Yh"/>
+                <constraint firstItem="diC-iE-Oqe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="5zT-jJ-dpi"/>
+                <constraint firstItem="diC-iE-Oqe" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="cxx-yp-JiP"/>
+                <constraint firstAttribute="bottom" secondItem="diC-iE-Oqe" secondAttribute="bottom" id="sgs-6a-Phi"/>
+                <constraint firstAttribute="trailing" secondItem="diC-iE-Oqe" secondAttribute="trailing" id="xHW-Yx-Npq"/>
             </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="addToAirRobeSwitch" destination="0fP-yw-WwF" id="4ev-WZ-inm"/>
                 <outlet property="arrowImageView" destination="Hpz-Z1-uaW" id="e9p-Nm-PYK"/>
                 <outlet property="descriptionLabel" destination="sgg-2c-UU8" id="5vW-Se-MJr"/>
                 <outlet property="detailedDescriptionLabel" destination="qMv-u6-Ipi" id="Yqp-kx-43s"/>
+                <outlet property="extraInfoContainer" destination="A4u-oB-nyq" id="AR4-0D-xvq"/>
                 <outlet property="extraInfoLabel" destination="dp7-jD-L3u" id="BS1-CU-3BT"/>
                 <outlet property="mainContainerExpandButton" destination="Fvc-fX-KYx" id="EHH-g8-yAb"/>
                 <outlet property="mainContainerView" destination="swg-ok-dY1" id="wOr-lj-dRN"/>
-                <outlet property="margin" destination="6RC-xd-TY7" id="Yi4-aG-ukC"/>
                 <outlet property="potentialValueLabel" destination="hs1-3E-o7n" id="LGD-Oq-DCX"/>
                 <outlet property="potentialValueLoading" destination="iiN-y3-ZaS" id="dTL-Zv-XXm"/>
                 <outlet property="subTitleContainer" destination="9Tx-ha-3VQ" id="oei-hP-obs"/>
                 <outlet property="titleLabel" destination="FkA-oy-yGJ" id="qf3-lf-m0o"/>
                 <outlet property="widgetStackView" destination="vZ6-M6-d25" id="TvF-SO-G4Q"/>
             </connections>
-            <point key="canvasLocation" x="131.8840579710145" y="96.428571428571431"/>
+            <point key="canvasLocation" x="262.31884057971018" y="-49.888392857142854"/>
         </view>
     </objects>
     <resources>

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
@@ -14,20 +14,20 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="diC-iE-Oqe">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="diC-iE-Oqe">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="swg-ok-dY1">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="73"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="103"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZ6-M6-d25">
-                                    <rect key="frame" x="10" y="10" width="394" height="53"/>
+                                    <rect key="frame" x="10" y="10" width="394" height="83"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="WEk-A1-pCz">
-                                            <rect key="frame" x="0.0" y="0.0" width="394" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="394" height="73"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0fP-yw-WwF">
-                                                    <rect key="frame" x="0.0" y="6" width="52" height="31"/>
+                                                    <rect key="frame" x="0.0" y="21" width="52" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="50" id="GRt-q5-tUe"/>
                                                     </constraints>
@@ -36,7 +36,7 @@
                                                     </connections>
                                                 </switch>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TEX-9a-wru">
-                                                    <rect key="frame" x="60" y="0.0" width="308" height="43"/>
+                                                    <rect key="frame" x="60" y="0.0" width="308" height="73"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v6L-SC-vLf">
                                                             <rect key="frame" x="0.0" y="0.0" width="308" height="18"/>
@@ -73,10 +73,10 @@
                                                             </subviews>
                                                         </stackView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
-                                                            <rect key="frame" x="0.0" y="23" width="308" height="20"/>
+                                                            <rect key="frame" x="0.0" y="23" width="308" height="50"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" horizontalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="50" height="20"/>
+                                                                    <rect key="frame" x="0.0" y="15" width="50" height="20"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="20" id="1G2-8w-PYB"/>
                                                                     </constraints>
@@ -85,16 +85,16 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
-                                                                    <rect key="frame" x="60" y="0.0" width="50" height="20"/>
+                                                                    <rect key="frame" x="60" y="0.0" width="50" height="50"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                                                     <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="iiN-y3-ZaS">
-                                                                    <rect key="frame" x="120" y="0.0" width="20" height="20"/>
+                                                                    <rect key="frame" x="120" y="15" width="20" height="20"/>
                                                                 </activityIndicatorView>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dPt-N0-3cH">
-                                                                    <rect key="frame" x="150" y="0.0" width="158" height="20"/>
+                                                                    <rect key="frame" x="150" y="0.0" width="158" height="50"/>
                                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 </view>
                                                             </subviews>
@@ -102,7 +102,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowDown" translatesAutoresizingMaskIntoConstraints="NO" id="Hpz-Z1-uaW">
-                                                    <rect key="frame" x="378" y="13.5" width="16" height="16"/>
+                                                    <rect key="frame" x="378" y="28.5" width="16" height="16"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="16" id="Fle-Ry-ean"/>
                                                         <constraint firstAttribute="height" constant="16" id="SQQ-Vc-rwb"/>
@@ -111,7 +111,7 @@
                                             </subviews>
                                         </stackView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-u6-Ipi" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
-                                            <rect key="frame" x="0.0" y="53" width="394" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="83" width="394" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -128,10 +128,10 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A4u-oB-nyq">
-                            <rect key="frame" x="0.0" y="83" width="414" height="217"/>
+                            <rect key="frame" x="0.0" y="113" width="414" height="187"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dp7-jD-L3u" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
-                                    <rect key="frame" x="10" y="0.0" width="394" height="217"/>
+                                    <rect key="frame" x="10" y="0.0" width="394" height="187"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                     <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
@@ -14,113 +14,104 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="diC-iE-Oqe">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="diC-iE-Oqe">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="swg-ok-dY1">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="290"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="73"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZ6-M6-d25">
-                                    <rect key="frame" x="10" y="10" width="394" height="270"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZ6-M6-d25">
+                                    <rect key="frame" x="10" y="10" width="394" height="53"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P3t-bM-4hC">
-                                            <rect key="frame" x="0.0" y="0.0" width="394" height="40"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="WEk-A1-pCz">
+                                            <rect key="frame" x="0.0" y="0.0" width="394" height="43"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0fP-yw-WwF">
-                                                    <rect key="frame" x="0.0" y="4.5" width="51" height="31"/>
+                                                    <rect key="frame" x="0.0" y="6" width="52" height="31"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="50" id="GRt-q5-tUe"/>
+                                                    </constraints>
                                                     <connections>
                                                         <action selector="onTapSwitch:" destination="iN0-l3-epB" eventType="valueChanged" id="0bY-DC-bfM"/>
                                                     </connections>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FkA-oy-yGJ">
-                                                    <rect key="frame" x="59" y="12" width="0.0" height="0.0"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                    <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="airRobeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="fCW-So-70G">
-                                                    <rect key="frame" x="69" y="0.0" width="90" height="18"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="90" id="JU6-dk-PHI"/>
-                                                        <constraint firstAttribute="height" constant="18" id="WQJ-0i-qvO"/>
-                                                    </constraints>
-                                                </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
-                                                    <rect key="frame" x="59" y="23" width="309" height="17"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TEX-9a-wru">
+                                                    <rect key="frame" x="60" y="0.0" width="308" height="43"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
-                                                            <rect key="frame" x="0.0" y="0.0" width="82.5" height="17"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                            <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u7d-E3-PXv">
-                                                            <rect key="frame" x="82.5" y="0.0" width="5" height="17"/>
-                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="5" id="4Rl-eR-dAp"/>
-                                                            </constraints>
-                                                        </view>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
-                                                            <rect key="frame" x="87.5" y="0.0" width="184.5" height="17"/>
-                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
-                                                            <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dVN-53-Wge">
-                                                            <rect key="frame" x="272" y="0.0" width="5" height="17"/>
-                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="5" id="ihS-fc-3Pn"/>
-                                                            </constraints>
-                                                        </view>
-                                                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="iiN-y3-ZaS">
-                                                            <rect key="frame" x="277" y="0.0" width="20" height="17"/>
-                                                        </activityIndicatorView>
-                                                        <view contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="dPt-N0-3cH">
-                                                            <rect key="frame" x="297" y="0.0" width="12" height="17"/>
-                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                        </view>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v6L-SC-vLf">
+                                                            <rect key="frame" x="0.0" y="0.0" width="308" height="18"/>
+                                                            <subviews>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ncf-aW-Rnu">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="40" height="18"/>
+                                                                    <subviews>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FkA-oy-yGJ">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="40" height="24"/>
+                                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                            <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                    </subviews>
+                                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="bottom" secondItem="FkA-oy-yGJ" secondAttribute="bottom" constant="-6" id="8gY-qE-GLM"/>
+                                                                        <constraint firstItem="FkA-oy-yGJ" firstAttribute="top" secondItem="Ncf-aW-Rnu" secondAttribute="top" id="IQ8-ed-UKO"/>
+                                                                        <constraint firstItem="FkA-oy-yGJ" firstAttribute="leading" secondItem="Ncf-aW-Rnu" secondAttribute="leading" id="RAb-gK-fFL"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="FkA-oy-yGJ" secondAttribute="trailing" id="npC-R9-zXv"/>
+                                                                    </constraints>
+                                                                </view>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="airRobeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="fCW-So-70G">
+                                                                    <rect key="frame" x="50" y="0.0" width="90" height="18"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="90" id="JU6-dk-PHI"/>
+                                                                        <constraint firstAttribute="height" constant="18" id="WQJ-0i-qvO"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FhL-9U-dFi">
+                                                                    <rect key="frame" x="150" y="0.0" width="158" height="18"/>
+                                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                </view>
+                                                            </subviews>
+                                                        </stackView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
+                                                            <rect key="frame" x="0.0" y="23" width="308" height="20"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" horizontalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="50" height="20"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="20" id="1G2-8w-PYB"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                                    <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
+                                                                    <rect key="frame" x="60" y="0.0" width="50" height="20"/>
+                                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                                    <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="iiN-y3-ZaS">
+                                                                    <rect key="frame" x="120" y="0.0" width="20" height="20"/>
+                                                                </activityIndicatorView>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dPt-N0-3cH">
+                                                                    <rect key="frame" x="150" y="0.0" width="158" height="20"/>
+                                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                </view>
+                                                            </subviews>
+                                                        </stackView>
                                                     </subviews>
                                                 </stackView>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowDown" translatesAutoresizingMaskIntoConstraints="NO" id="Hpz-Z1-uaW">
-                                                    <rect key="frame" x="378" y="12" width="16" height="16"/>
+                                                    <rect key="frame" x="378" y="13.5" width="16" height="16"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="16" id="Fle-Ry-ean"/>
                                                         <constraint firstAttribute="height" constant="16" id="SQQ-Vc-rwb"/>
                                                     </constraints>
                                                 </imageView>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fvc-fX-KYx">
-                                                    <rect key="frame" x="59" y="0.0" width="335" height="40"/>
-                                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                                    <connections>
-                                                        <action selector="onTapExpand:" destination="iN0-l3-epB" eventType="touchUpInside" id="iQd-yu-g7K"/>
-                                                    </connections>
-                                                </button>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="40" id="192-vZ-i2i"/>
-                                                <constraint firstItem="9Tx-ha-3VQ" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="1Gj-AK-5kU"/>
-                                                <constraint firstItem="fCW-So-70G" firstAttribute="top" secondItem="P3t-bM-4hC" secondAttribute="top" id="GYd-GS-Kbw"/>
-                                                <constraint firstItem="FkA-oy-yGJ" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="N2M-7M-FYP"/>
-                                                <constraint firstItem="0fP-yw-WwF" firstAttribute="leading" secondItem="P3t-bM-4hC" secondAttribute="leading" id="Tqf-2p-dg0"/>
-                                                <constraint firstItem="fCW-So-70G" firstAttribute="leading" secondItem="FkA-oy-yGJ" secondAttribute="trailing" constant="10" id="U5C-wu-ejW"/>
-                                                <constraint firstItem="Hpz-Z1-uaW" firstAttribute="centerY" secondItem="P3t-bM-4hC" secondAttribute="centerY" id="VU7-KX-keK"/>
-                                                <constraint firstAttribute="trailing" secondItem="Fvc-fX-KYx" secondAttribute="trailing" id="aUl-4m-myX"/>
-                                                <constraint firstAttribute="trailing" secondItem="Hpz-Z1-uaW" secondAttribute="trailing" id="dkB-Ys-ZRA"/>
-                                                <constraint firstItem="0fP-yw-WwF" firstAttribute="centerY" secondItem="P3t-bM-4hC" secondAttribute="centerY" id="fGw-rQ-lEI"/>
-                                                <constraint firstAttribute="bottom" secondItem="9Tx-ha-3VQ" secondAttribute="bottom" id="h6J-cB-aXO"/>
-                                                <constraint firstAttribute="bottom" secondItem="Fvc-fX-KYx" secondAttribute="bottom" id="ivf-AI-AbE"/>
-                                                <constraint firstItem="Fvc-fX-KYx" firstAttribute="leading" secondItem="0fP-yw-WwF" secondAttribute="trailing" constant="10" id="jrG-Zs-Al7"/>
-                                                <constraint firstItem="Fvc-fX-KYx" firstAttribute="top" secondItem="P3t-bM-4hC" secondAttribute="top" id="khE-t4-PvJ"/>
-                                                <constraint firstItem="FkA-oy-yGJ" firstAttribute="centerY" secondItem="fCW-So-70G" secondAttribute="centerY" constant="3" id="sqL-06-dpx"/>
-                                                <constraint firstItem="9Tx-ha-3VQ" firstAttribute="top" secondItem="fCW-So-70G" secondAttribute="bottom" constant="5" id="vz1-yD-SUm"/>
-                                                <constraint firstItem="Hpz-Z1-uaW" firstAttribute="leading" secondItem="9Tx-ha-3VQ" secondAttribute="trailing" constant="10" id="wmy-19-Nhz"/>
-                                            </constraints>
-                                        </view>
+                                        </stackView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMv-u6-Ipi" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
-                                            <rect key="frame" x="0.0" y="270" width="394" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="53" width="394" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -137,10 +128,10 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A4u-oB-nyq">
-                            <rect key="frame" x="0.0" y="300" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="83" width="414" height="217"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dp7-jD-L3u" customClass="AirRobeHyperlinkLabel" customModule="AirRobeWidget">
-                                    <rect key="frame" x="10" y="0.0" width="394" height="0.0"/>
+                                    <rect key="frame" x="10" y="0.0" width="394" height="217"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                     <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
@@ -172,12 +163,12 @@
                 <outlet property="detailedDescriptionLabel" destination="qMv-u6-Ipi" id="Yqp-kx-43s"/>
                 <outlet property="extraInfoContainer" destination="A4u-oB-nyq" id="AR4-0D-xvq"/>
                 <outlet property="extraInfoLabel" destination="dp7-jD-L3u" id="BS1-CU-3BT"/>
-                <outlet property="mainContainerExpandButton" destination="Fvc-fX-KYx" id="EHH-g8-yAb"/>
                 <outlet property="mainContainerView" destination="swg-ok-dY1" id="wOr-lj-dRN"/>
                 <outlet property="potentialValueLabel" destination="hs1-3E-o7n" id="LGD-Oq-DCX"/>
                 <outlet property="potentialValueLoading" destination="iiN-y3-ZaS" id="dTL-Zv-XXm"/>
                 <outlet property="subTitleContainer" destination="9Tx-ha-3VQ" id="oei-hP-obs"/>
                 <outlet property="titleLabel" destination="FkA-oy-yGJ" id="qf3-lf-m0o"/>
+                <outlet property="topContentContainer" destination="TEX-9a-wru" id="SXN-bL-Fip"/>
                 <outlet property="widgetStackView" destination="vZ6-M6-d25" id="TvF-SO-G4Q"/>
             </connections>
             <point key="canvasLocation" x="262.31884057971018" y="-49.888392857142854"/>

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
@@ -75,7 +75,7 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
                                                             <rect key="frame" x="0.0" y="23" width="308" height="50"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" horizontalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
                                                                     <rect key="frame" x="0.0" y="15" width="50" height="20"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="20" id="1G2-8w-PYB"/>
@@ -84,7 +84,7 @@
                                                                     <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" horizontalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
                                                                     <rect key="frame" x="55" y="0.0" width="50" height="50"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                                                     <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.xib
@@ -72,7 +72,7 @@
                                                                 </view>
                                                             </subviews>
                                                         </stackView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
+                                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="9Tx-ha-3VQ">
                                                             <rect key="frame" x="0.0" y="23" width="308" height="50"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" horizontalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sgg-2c-UU8">
@@ -85,16 +85,16 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hs1-3E-o7n">
-                                                                    <rect key="frame" x="60" y="0.0" width="50" height="50"/>
+                                                                    <rect key="frame" x="55" y="0.0" width="50" height="50"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                                                     <color key="textColor" red="0.13725490196078433" green="0.13725490196078433" blue="0.13725490196078433" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="iiN-y3-ZaS">
-                                                                    <rect key="frame" x="120" y="15" width="20" height="20"/>
+                                                                    <rect key="frame" x="110" y="15" width="20" height="20"/>
                                                                 </activityIndicatorView>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dPt-N0-3cH">
-                                                                    <rect key="frame" x="150" y="0.0" width="158" height="50"/>
+                                                                    <rect key="frame" x="135" y="0.0" width="173" height="50"/>
                                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 </view>
                                                             </subviews>

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -34,7 +34,6 @@ final class AirRobeOptInViewModel {
 
     private lazy var apiService = AirRobeApiService()
     private var cancellable: AnyCancellable?
-    var alreadyInitialized: Bool = false
 
     @Published var isAllSet: AirRobeWidgetLoadState = .initializing
     @Published var potentialPrice: String = ""
@@ -47,29 +46,28 @@ final class AirRobeOptInViewModel {
             isAllSet = .noCategoryMappingInfo
             return
         }
-        if !alreadyInitialized {
-            AirRobeUtils.telemetryEvent(
-                eventName: TelemetryEventName.pageView.rawValue,
-                pageName: PageName.product.rawValue,
-                brand: brand,
-                material: material,
-                category: category,
-                department: department
-            )
-            AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.product.rawValue)
-            alreadyInitialized = true
-            if category.isEmpty {
-                isAllSet = .paramIssue
-                return
-            }
-            let eligibility = AirRobeShoppingDataModelInstance.shared.categoryMapping.checkCategoryEligible(items: [category])
-            isAllSet = (eligibility.eligible && !shoppingDataModel.isBelowPriceThreshold(department: department, price: priceCents)) ? .eligible : .notEligible
-            if isAllSet == .eligible {
-                AirRobeUtils.dispatchEvent(eventName: EventName.widgetRender.rawValue, pageName: PageName.product.rawValue)
-                callPriceEngine(category: eligibility.to)
-            } else {
-                AirRobeUtils.dispatchEvent(eventName: EventName.widgetNotRendered.rawValue, pageName: PageName.product.rawValue)
-            }
+
+        AirRobeUtils.telemetryEvent(
+            eventName: TelemetryEventName.pageView.rawValue,
+            pageName: PageName.product.rawValue,
+            brand: brand,
+            material: material,
+            category: category,
+            department: department
+        )
+        AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.product.rawValue)
+
+        if category.isEmpty {
+            isAllSet = .paramIssue
+            return
+        }
+        let eligibility = AirRobeShoppingDataModelInstance.shared.categoryMapping.checkCategoryEligible(items: [category])
+        isAllSet = (eligibility.eligible && !shoppingDataModel.isBelowPriceThreshold(department: department, price: priceCents)) ? .eligible : .notEligible
+        if isAllSet == .eligible {
+            AirRobeUtils.dispatchEvent(eventName: EventName.widgetRender.rawValue, pageName: PageName.product.rawValue)
+            callPriceEngine(category: eligibility.to)
+        } else {
+            AirRobeUtils.dispatchEvent(eventName: EventName.widgetNotRendered.rawValue, pageName: PageName.product.rawValue)
         }
     }
 
@@ -82,23 +80,22 @@ final class AirRobeOptInViewModel {
             UserDefaults.standard.OrderOptedIn = false
             return
         }
-        if !alreadyInitialized {
-            AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.cart.rawValue)
-            AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.cart.rawValue)
-            alreadyInitialized = true
-            if items.isEmpty {
-                isAllSet = .paramIssue
-                UserDefaults.standard.OrderOptedIn = false
-                return
-            }
-            let eligibility = AirRobeShoppingDataModelInstance.shared.categoryMapping.checkCategoryEligible(items: items)
-            isAllSet = eligibility.eligible ? .eligible : .notEligible
-            UserDefaults.standard.OrderOptedIn = eligibility.eligible && UserDefaults.standard.OptedIn ? true : false
-            if isAllSet == .eligible {
-                AirRobeUtils.dispatchEvent(eventName: EventName.widgetRender.rawValue, pageName: PageName.cart.rawValue)
-            } else {
-                AirRobeUtils.dispatchEvent(eventName: EventName.widgetNotRendered.rawValue, pageName: PageName.cart.rawValue)
-            }
+
+        AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.cart.rawValue)
+        AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.cart.rawValue)
+
+        if items.isEmpty {
+            isAllSet = .paramIssue
+            UserDefaults.standard.OrderOptedIn = false
+            return
+        }
+        let eligibility = AirRobeShoppingDataModelInstance.shared.categoryMapping.checkCategoryEligible(items: items)
+        isAllSet = eligibility.eligible ? .eligible : .notEligible
+        UserDefaults.standard.OrderOptedIn = eligibility.eligible && UserDefaults.standard.OptedIn ? true : false
+        if isAllSet == .eligible {
+            AirRobeUtils.dispatchEvent(eventName: EventName.widgetRender.rawValue, pageName: PageName.cart.rawValue)
+        } else {
+            AirRobeUtils.dispatchEvent(eventName: EventName.widgetNotRendered.rawValue, pageName: PageName.cart.rawValue)
         }
     }
 

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationView.xib
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationView.xib
@@ -21,16 +21,28 @@
                             <rect key="frame" x="0.0" y="0.0" width="374" height="143"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-2k-ZST">
-                                    <rect key="frame" x="0.0" y="0.0" width="374" height="143"/>
+                                    <rect key="frame" x="23.5" y="0.0" width="327" height="143"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1on-WJ-75x">
-                                            <rect key="frame" x="0.0" y="46.5" width="287" height="50"/>
-                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
-                                            <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CbM-5Z-nEb">
+                                            <rect key="frame" x="0.0" y="7.5" width="240" height="128"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1on-WJ-75x">
+                                                    <rect key="frame" x="0.0" y="0.0" width="240" height="133"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
+                                                    <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstItem="1on-WJ-75x" firstAttribute="top" secondItem="CbM-5Z-nEb" secondAttribute="top" id="K4x-oM-n7x"/>
+                                                <constraint firstItem="1on-WJ-75x" firstAttribute="leading" secondItem="CbM-5Z-nEb" secondAttribute="leading" id="NsZ-Ig-c2Z"/>
+                                                <constraint firstAttribute="trailing" secondItem="1on-WJ-75x" secondAttribute="trailing" id="VdT-ic-jlI"/>
+                                                <constraint firstAttribute="bottom" secondItem="1on-WJ-75x" secondAttribute="bottom" constant="-5" id="Xyx-Sb-O8Y"/>
+                                            </constraints>
+                                        </view>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="airRobeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="mOd-bW-Lwo">
-                                            <rect key="frame" x="292" y="60" width="82" height="23"/>
+                                            <rect key="frame" x="245" y="60" width="82" height="23"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="23" id="Dig-W4-gyr"/>
                                                 <constraint firstAttribute="width" constant="82" id="PQO-k2-j2m"/>

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationView.xib
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationView.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,94 +11,96 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="AirRobeOrderConfirmationView" customModule="AirRobeWidget">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="243"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qa0-0h-dtG">
-                    <rect key="frame" x="163.5" y="59" width="87" height="23"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="zAn-3n-Jil">
+                    <rect key="frame" x="20" y="15" width="374" height="213"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1on-WJ-75x">
-                            <rect key="frame" x="0.0" y="13.5" width="0.0" height="0.0"/>
-                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JUi-j6-JMP">
+                            <rect key="frame" x="0.0" y="0.0" width="374" height="143"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-2k-ZST">
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="143"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1on-WJ-75x">
+                                            <rect key="frame" x="0.0" y="46.5" width="287" height="50"/>
+                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
+                                            <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="airRobeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="mOd-bW-Lwo">
+                                            <rect key="frame" x="292" y="60" width="82" height="23"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="23" id="Dig-W4-gyr"/>
+                                                <constraint firstAttribute="width" constant="82" id="PQO-k2-j2m"/>
+                                            </constraints>
+                                        </imageView>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="s4B-2k-ZST" secondAttribute="bottom" id="JGr-GW-qUi"/>
+                                <constraint firstItem="s4B-2k-ZST" firstAttribute="top" secondItem="JUi-j6-JMP" secondAttribute="top" id="R5r-oL-zrN"/>
+                                <constraint firstItem="s4B-2k-ZST" firstAttribute="centerX" secondItem="JUi-j6-JMP" secondAttribute="centerX" id="cKS-oF-EXt"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qxa-zn-Xla">
+                            <rect key="frame" x="0.0" y="158" width="374" height="0.0"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
                             <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="airRobeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="mOd-bW-Lwo">
-                            <rect key="frame" x="5" y="0.0" width="82" height="23"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Fa-yf-gHU">
+                            <rect key="frame" x="0.0" y="173" width="374" height="40"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sm7-tj-Ipk">
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="40"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="onTapActivate:" destination="iN0-l3-epB" eventType="touchUpInside" id="2nG-A9-1bL"/>
+                                    </connections>
+                                </button>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Jn-QE-jkN">
+                                    <rect key="frame" x="10" y="10" width="354" height="20"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="MpC-Lk-Jwy">
+                                    <rect key="frame" x="177" y="10" width="20" height="20"/>
+                                    <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </activityIndicatorView>
+                            </subviews>
                             <constraints>
-                                <constraint firstAttribute="height" constant="23" id="Dig-W4-gyr"/>
-                                <constraint firstAttribute="width" constant="82" id="PQO-k2-j2m"/>
+                                <constraint firstAttribute="bottom" secondItem="Sm7-tj-Ipk" secondAttribute="bottom" id="5w3-kS-hjj"/>
+                                <constraint firstAttribute="trailing" secondItem="Sm7-tj-Ipk" secondAttribute="trailing" id="6Cb-et-lrn"/>
+                                <constraint firstItem="Sm7-tj-Ipk" firstAttribute="leading" secondItem="4Fa-yf-gHU" secondAttribute="leading" id="CRc-DX-FAR"/>
+                                <constraint firstItem="MpC-Lk-Jwy" firstAttribute="centerY" secondItem="4Fa-yf-gHU" secondAttribute="centerY" id="J2e-bI-VTM"/>
+                                <constraint firstItem="MpC-Lk-Jwy" firstAttribute="centerX" secondItem="4Fa-yf-gHU" secondAttribute="centerX" id="ML4-CR-6PN"/>
+                                <constraint firstAttribute="bottom" secondItem="2Jn-QE-jkN" secondAttribute="bottom" constant="10" id="aAz-vV-Pj3"/>
+                                <constraint firstAttribute="trailing" secondItem="2Jn-QE-jkN" secondAttribute="trailing" constant="10" id="hfB-q8-m0b"/>
+                                <constraint firstAttribute="height" constant="40" id="l2M-4N-MZD"/>
+                                <constraint firstItem="2Jn-QE-jkN" firstAttribute="leading" secondItem="4Fa-yf-gHU" secondAttribute="leading" constant="10" id="lii-xV-Ykf"/>
+                                <constraint firstItem="Sm7-tj-Ipk" firstAttribute="top" secondItem="4Fa-yf-gHU" secondAttribute="top" id="vNH-kI-bIP"/>
+                                <constraint firstItem="2Jn-QE-jkN" firstAttribute="top" secondItem="4Fa-yf-gHU" secondAttribute="top" constant="10" id="yPr-Jr-JQo"/>
                             </constraints>
-                        </imageView>
+                        </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="mOd-bW-Lwo" secondAttribute="bottom" id="8rk-WR-jhw"/>
-                        <constraint firstAttribute="trailing" secondItem="mOd-bW-Lwo" secondAttribute="trailing" id="ALA-ec-fR4"/>
-                        <constraint firstItem="1on-WJ-75x" firstAttribute="leading" secondItem="Qa0-0h-dtG" secondAttribute="leading" id="Dvq-DU-Ujj"/>
-                        <constraint firstItem="1on-WJ-75x" firstAttribute="centerY" secondItem="mOd-bW-Lwo" secondAttribute="centerY" constant="2" id="Lrm-Lg-tCT"/>
-                        <constraint firstItem="mOd-bW-Lwo" firstAttribute="leading" secondItem="1on-WJ-75x" secondAttribute="trailing" constant="5" id="hGu-GP-3Eh"/>
-                        <constraint firstItem="mOd-bW-Lwo" firstAttribute="top" secondItem="Qa0-0h-dtG" secondAttribute="top" id="vPI-6k-Yry"/>
-                    </constraints>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qxa-zn-Xla">
-                    <rect key="frame" x="20" y="97" width="374" height="695"/>
-                    <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
-                    <color key="textColor" red="0.13725490200000001" green="0.13725490200000001" blue="0.13725490200000001" alpha="1" colorSpace="calibratedRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Fa-yf-gHU">
-                    <rect key="frame" x="20" y="807" width="374" height="40"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sm7-tj-Ipk">
-                            <rect key="frame" x="0.0" y="0.0" width="374" height="40"/>
-                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                            <state key="normal">
-                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </state>
-                            <connections>
-                                <action selector="onTapActivate:" destination="iN0-l3-epB" eventType="touchUpInside" id="2nG-A9-1bL"/>
-                            </connections>
-                        </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Jn-QE-jkN">
-                            <rect key="frame" x="10" y="10" width="354" height="20"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="MpC-Lk-Jwy">
-                            <rect key="frame" x="177" y="10" width="20" height="20"/>
-                            <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        </activityIndicatorView>
-                    </subviews>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="Sm7-tj-Ipk" secondAttribute="bottom" id="5w3-kS-hjj"/>
-                        <constraint firstAttribute="trailing" secondItem="Sm7-tj-Ipk" secondAttribute="trailing" id="6Cb-et-lrn"/>
-                        <constraint firstItem="Sm7-tj-Ipk" firstAttribute="leading" secondItem="4Fa-yf-gHU" secondAttribute="leading" id="CRc-DX-FAR"/>
-                        <constraint firstItem="MpC-Lk-Jwy" firstAttribute="centerY" secondItem="4Fa-yf-gHU" secondAttribute="centerY" id="J2e-bI-VTM"/>
-                        <constraint firstItem="MpC-Lk-Jwy" firstAttribute="centerX" secondItem="4Fa-yf-gHU" secondAttribute="centerX" id="ML4-CR-6PN"/>
-                        <constraint firstAttribute="bottom" secondItem="2Jn-QE-jkN" secondAttribute="bottom" constant="10" id="aAz-vV-Pj3"/>
-                        <constraint firstAttribute="trailing" secondItem="2Jn-QE-jkN" secondAttribute="trailing" constant="10" id="hfB-q8-m0b"/>
-                        <constraint firstAttribute="height" constant="40" id="l2M-4N-MZD"/>
-                        <constraint firstItem="2Jn-QE-jkN" firstAttribute="leading" secondItem="4Fa-yf-gHU" secondAttribute="leading" constant="10" id="lii-xV-Ykf"/>
-                        <constraint firstItem="Sm7-tj-Ipk" firstAttribute="top" secondItem="4Fa-yf-gHU" secondAttribute="top" id="vNH-kI-bIP"/>
-                        <constraint firstItem="2Jn-QE-jkN" firstAttribute="top" secondItem="4Fa-yf-gHU" secondAttribute="top" constant="10" id="yPr-Jr-JQo"/>
-                    </constraints>
-                </view>
+                </stackView>
             </subviews>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="Qxa-zn-Xla" firstAttribute="top" secondItem="Qa0-0h-dtG" secondAttribute="bottom" constant="15" id="5OP-9u-Mq9"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Qxa-zn-Xla" secondAttribute="trailing" constant="20" id="GhV-aB-7a6"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="4Fa-yf-gHU" secondAttribute="trailing" constant="20" id="Q8c-nb-hdl"/>
-                <constraint firstItem="Qa0-0h-dtG" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="Vj6-0a-M6l"/>
-                <constraint firstItem="4Fa-yf-gHU" firstAttribute="top" secondItem="Qxa-zn-Xla" secondAttribute="bottom" constant="15" id="eOq-dh-COd"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="4Fa-yf-gHU" secondAttribute="bottom" constant="15" id="q4M-uy-LHp"/>
-                <constraint firstItem="Qa0-0h-dtG" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="15" id="r7Y-PS-zUc"/>
-                <constraint firstItem="4Fa-yf-gHU" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="tEX-Wv-fQg"/>
-                <constraint firstItem="Qxa-zn-Xla" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="vOV-4s-Iep"/>
+                <constraint firstAttribute="trailing" secondItem="zAn-3n-Jil" secondAttribute="trailing" priority="999" constant="20" id="0ET-X7-uL2"/>
+                <constraint firstAttribute="bottom" secondItem="zAn-3n-Jil" secondAttribute="bottom" priority="999" constant="15" id="LPg-wQ-TWY"/>
+                <constraint firstItem="zAn-3n-Jil" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" priority="999" constant="20" id="eWN-pn-CS7"/>
+                <constraint firstItem="zAn-3n-Jil" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" priority="999" constant="15" id="gFL-7v-v0O"/>
             </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="activateContainerView" destination="4Fa-yf-gHU" id="dh2-OM-kuP"/>
                 <outlet property="activateLabel" destination="2Jn-QE-jkN" id="bUX-kU-CEC"/>
@@ -107,7 +108,7 @@
                 <outlet property="descriptionLabel" destination="Qxa-zn-Xla" id="ZsR-ob-d5k"/>
                 <outlet property="titleLabel" destination="1on-WJ-75x" id="nJO-KS-Jza"/>
             </connections>
-            <point key="canvasLocation" x="131.8840579710145" y="63.616071428571423"/>
+            <point key="canvasLocation" x="131.8840579710145" y="-378.68303571428572"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
**Issues during this PR**

During this PR, I noticed there can be a few improvements in optin widget.
So basically, it's mostly based on `UIView` with a few `UIStackView` combinations. but I found it can be fully designed by using `UIStackView` and I updated the UI based on `UIStackView`.
But during the updating UI, I noticed a few issues down below.

- [x] links are not clickable in the cart page of the demo
- [x] update optin widget ui by using stackview (not an issue, but improvement)
- [x] solve "By opting in you agree..." text height issue when expanded
- [x] "Wear now, resell later ..." text cutting off issue. So for this issue, It looks like there is enough space to show the full text, but "Wear now" is still cut off.
- [x] widget is not hidden when we remove an item and the remaining items are not eligible in the cart page of the demo


### Test plans

 **How it works**
We are currently getting company name, privacy url, find out more url, category mapping data etc. from `connector/graphql` with below query.
```
query GetShoppingData ($appId: String) {
  shop(appId: $appId) {
    name
    privacyUrl
    popupFindOutMoreUrl
    categoryMappings(mappedOrExcludedOnly: true) {
      from
      to
      excluded
    }
    minimumPriceThresholds {
      default
      department
      minimumPriceCents
    }
  }
}
```

if `privacyUrl` is `null`, we hide "By opting in..." text block.
if not, we use this `privacyUrl` for the privacy link in "By opting in..." text block.
Also we use `name` value for the company name in "By opting in..." text block.
And we use `popupFindOutMoreUrl` for the find out more URL in Learn More popup widget.

-- Note
`name` and `popupFindOutMoreUrl` are not nullable while `privacyUrl` is nullable.
And in order to test it successfully, `categoryMappings` should have data. but optional.

**Test Environment**
- Open our demo project through XCode.
- Inside `../AirRobeDemo/Application/AppDelegate -> AppDelegate class -> application()`, we have `initialize` function which has `appId` and `mode` as params.
- Update these `appId` and `mode` and test out the below cases.

**Test Cases**
We can test this out by simulating the connector api call with a specific `app_id`.
- [x] check whether "By opting in ..." text block is hidden if the privacy URL is `null`.
- [x] check whether it's updated with company name and privacy URL as per it comes from the connector based on `app_id`.
- [x] check whether it's updated with popup find more URL as per it comes from the connector based on `app_id`.
