### PR TITLE
Eli/create opted out order

### DIFF
--- a/AirRobeDemo/AirRobeDemo/Controllers/ConfirmationViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/ConfirmationViewController.swift
@@ -20,7 +20,7 @@ final class ConfirmationViewController: UIViewController {
         airRobeConfirmation.initialize(
             orderId: orderId,
             email: email,
-            orderSubTotalCents: 10000
+            orderSubtotalCents: 10000
         )
         // This part is how you can configure the colors of the widget
 //        airRobeConfirmation.borderColor = .red

--- a/AirRobeDemo/AirRobeDemo/Controllers/ConfirmationViewController.swift
+++ b/AirRobeDemo/AirRobeDemo/Controllers/ConfirmationViewController.swift
@@ -19,7 +19,8 @@ final class ConfirmationViewController: UIViewController {
         super.viewDidLoad()
         airRobeConfirmation.initialize(
             orderId: orderId,
-            email: email
+            email: email,
+            orderSubTotalCents: 10000
         )
         // This part is how you can configure the colors of the widget
 //        airRobeConfirmation.borderColor = .red

--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -57,6 +57,16 @@ enum AirRobeStrings {
                 }
             """
 
+    // MARK: - Create Opted Out Order Query Strings
+    static let CreateOptedOutOrderQuery = """
+                mutation CreateOptedOutOrder ($input: CreateOptedOutOrderMutationInput!) {
+                  createOptedOutOrder (input: $input) {
+                    created
+                    error
+                  }
+                }
+            """
+
     // MARK: - Learn More Alert View Controller Strings
     static let learnMoreTitle = "HOW IT WORKS"
     static let learnMoreStep1Title = "1. ADD TO AIRROBE"

--- a/Sources/AirRobeWidget/Service/AirRobeApiService.swift
+++ b/Sources/AirRobeWidget/Service/AirRobeApiService.swift
@@ -60,6 +60,15 @@ final class AirRobeApiService: AirRobeNetworkClient {
         return execute(endpoint.asURLRequest(), decodingType: AirRobeEmailCheckResponseModel.self)
     }
 
+    func createOptedOutOrder(operation: AirRobeGraphQLOperation<CreateOptedOutOrderInput>) -> AnyPublisher<AirRobeCreateOptedOutOrderResponseModel, Error> {
+        var endpoint = AirRobeEndpoint.createOptedOutOrder(operation: operation)
+        endpoint.requestBody = endpoint.requestBody.merging(additionalRequestBodyParams) { (current, _) in current }
+        #if DEBUG
+        dump(endpoint.asURLRequest())
+        #endif
+        return execute(endpoint.asURLRequest(), decodingType: AirRobeCreateOptedOutOrderResponseModel.self)
+    }
+
     func telemetryEvent(
         eventName: String,
         pageName: String,

--- a/Sources/AirRobeWidget/Service/Endpoints/AirRobeEndpoint.swift
+++ b/Sources/AirRobeWidget/Service/Endpoints/AirRobeEndpoint.swift
@@ -24,6 +24,7 @@ struct AirRobeEndpoint {
     var requestBody: [String: Any]
     var getShoppingDataRequestBody: AirRobeGraphQLOperation<AppIdInput>?
     var emailCheckRequestBody: AirRobeGraphQLOperation<EmailInput>?
+    var createOptedOutOrderRequestBody: AirRobeGraphQLOperation<CreateOptedOutOrderInput>?
     var customHeaders: [String: String]
     var scheme: String
     var host: String
@@ -36,6 +37,7 @@ struct AirRobeEndpoint {
         requestBody: [String: Any] = [:],
         getShoppingDataRequestBody: AirRobeGraphQLOperation<AppIdInput>? = nil,
         emailCheckRequestBody: AirRobeGraphQLOperation<EmailInput>? = nil,
+        createOptedOutOrderRequestBody: AirRobeGraphQLOperation<CreateOptedOutOrderInput>? = nil,
         customHeaders: [String: String] = [:],
         scheme: String = "https",
         host: String = priceEngineHost,
@@ -47,6 +49,7 @@ struct AirRobeEndpoint {
         self.requestBody = requestBody
         self.getShoppingDataRequestBody = getShoppingDataRequestBody
         self.emailCheckRequestBody = emailCheckRequestBody
+        self.createOptedOutOrderRequestBody = createOptedOutOrderRequestBody
         self.customHeaders = customHeaders
         self.scheme = scheme
         self.host = host
@@ -90,6 +93,13 @@ extension AirRobeEndpoint {
             #endif
         }
         if let graphQLRequestBody = emailCheckRequestBody, let bodyData = try? JSONEncoder().encode(graphQLRequestBody) {
+            request.httpBody = bodyData
+            #if DEBUG
+            let str = String(decoding: bodyData, as: UTF8.self)
+            print(str)
+            #endif
+        }
+        if let graphQLRequestBody = createOptedOutOrderRequestBody, let bodyData = try? JSONEncoder().encode(graphQLRequestBody) {
             request.httpBody = bodyData
             #if DEBUG
             let str = String(decoding: bodyData, as: UTF8.self)

--- a/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
+++ b/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
@@ -18,6 +18,10 @@ extension AirRobeEndpoint {
         return AirRobeEndpoint(method: .POST, path: "/graphql", emailCheckRequestBody: operation, host: emailCheckHost)
     }
 
+    static func createOptedOutOrder(operation: AirRobeGraphQLOperation<CreateOptedOutOrderInput>) -> AirRobeEndpoint {
+        return AirRobeEndpoint(method: .POST, path: "/graphql", createOptedOutOrderRequestBody: operation, host: configuration?.mode == .production ? AirRobeHost.airRobeConnectorProduction.rawValue : AirRobeHost.airRobeConnectorSandbox.rawValue)
+    }
+
     static func priceEngine(price: Double, rrp: Double?, category: String, brand: String?, material: String?) -> AirRobeEndpoint {
         let rrpVal: String? = {
             if let rrp = rrp {

--- a/Sources/AirRobeWidget/Service/GraphQLOperation/AirRobeGraphQLOperation.swift
+++ b/Sources/AirRobeWidget/Service/GraphQLOperation/AirRobeGraphQLOperation.swift
@@ -15,6 +15,17 @@ struct EmailInput: Encodable {
     let email: String
 }
 
+struct CreateOptedOutOrderInput: Encodable {
+    let id: String
+    let shopAppId: String
+    let subTotal: SubTotalInput
+}
+
+struct SubTotalInput: Encodable {
+    let cents: Int
+    let currency: String
+}
+
 struct AirRobeGraphQLOperation<Input: Encodable>: Encodable {
     var input: Input
     var operationString: String
@@ -45,6 +56,15 @@ extension AirRobeGraphQLOperation where Input == EmailInput {
         AirRobeGraphQLOperation(
             input: EmailInput(email: email),
             operationString: AirRobeStrings.CheckEmailQuery
+        )
+    }
+}
+
+extension AirRobeGraphQLOperation where Input == CreateOptedOutOrderInput {
+    static func fetchPost(with appId: String, with orderId: String, with cents: Int, with currency: String) -> Self {
+        AirRobeGraphQLOperation(
+            input: CreateOptedOutOrderInput(id: orderId, shopAppId: appId, subTotal: SubTotalInput(cents: cents, currency: currency)),
+            operationString: AirRobeStrings.CreateOptedOutOrderQuery
         )
     }
 }

--- a/Sources/AirRobeWidget/Service/GraphQLOperation/AirRobeGraphQLOperation.swift
+++ b/Sources/AirRobeWidget/Service/GraphQLOperation/AirRobeGraphQLOperation.swift
@@ -22,7 +22,7 @@ struct CreateOptedOutOrderInput: Encodable {
 struct CreateOptedOutOrderInputModel: Encodable {
     let id: String
     let shopAppId: String
-    let subTotal: SubTotalInput
+    let subtotal: SubTotalInput
 }
 
 struct SubTotalInput: Encodable {
@@ -71,7 +71,7 @@ extension AirRobeGraphQLOperation where Input == CreateOptedOutOrderInput {
                 input: CreateOptedOutOrderInputModel(
                     id: orderId,
                     shopAppId: appId,
-                    subTotal: SubTotalInput(
+                    subtotal: SubTotalInput(
                         cents: cents,
                         currency: currency
                     )

--- a/Sources/AirRobeWidget/Service/GraphQLOperation/AirRobeGraphQLOperation.swift
+++ b/Sources/AirRobeWidget/Service/GraphQLOperation/AirRobeGraphQLOperation.swift
@@ -16,6 +16,10 @@ struct EmailInput: Encodable {
 }
 
 struct CreateOptedOutOrderInput: Encodable {
+    let input: CreateOptedOutOrderInputModel
+}
+
+struct CreateOptedOutOrderInputModel: Encodable {
     let id: String
     let shopAppId: String
     let subTotal: SubTotalInput
@@ -63,7 +67,16 @@ extension AirRobeGraphQLOperation where Input == EmailInput {
 extension AirRobeGraphQLOperation where Input == CreateOptedOutOrderInput {
     static func fetchPost(with appId: String, with orderId: String, with cents: Int, with currency: String) -> Self {
         AirRobeGraphQLOperation(
-            input: CreateOptedOutOrderInput(id: orderId, shopAppId: appId, subTotal: SubTotalInput(cents: cents, currency: currency)),
+            input: CreateOptedOutOrderInput(
+                input: CreateOptedOutOrderInputModel(
+                    id: orderId,
+                    shopAppId: appId,
+                    subTotal: SubTotalInput(
+                        cents: cents,
+                        currency: currency
+                    )
+                )
+            ),
             operationString: AirRobeStrings.CreateOptedOutOrderQuery
         )
     }

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeCreateOptedOutOrderResponseModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeCreateOptedOutOrderResponseModel.swift
@@ -1,0 +1,24 @@
+//
+//  AirRobeCreateOptedOutOrderResponseModel.swift
+//  
+//
+//  Created by King on 8/17/22.
+//
+
+import Foundation
+
+// MARK: - GetShoppingDataModel
+struct AirRobeCreateOptedOutOrderResponseModel: Codable {
+    let data: AirRobeCreateOptedOutOrderDataModel
+}
+
+// MARK: - CreateOptedOutOrderDataModel
+struct AirRobeCreateOptedOutOrderDataModel: Codable {
+    let createOptedOutOrder: AirRobeCreateOptedOutOrderModel
+}
+
+// MARK: - CreateOptedOutOrderModel
+struct AirRobeCreateOptedOutOrderModel: Codable {
+    let created: Bool
+    let error: String?
+}

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeCreateOptedOutOrderResponseModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeCreateOptedOutOrderResponseModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// MARK: - GetShoppingDataModel
+// MARK: - CreateOptedOutOrderResponseModel
 struct AirRobeCreateOptedOutOrderResponseModel: Codable {
     let data: AirRobeCreateOptedOutOrderDataModel
 }

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -137,27 +137,21 @@ private extension AirRobeOptInViewModel {
         }()
         cancellable = apiService.priceEngine(price: priceCents, rrp: rrp, category: category, brand: brand, material: material)
             .sink(receiveCompletion: { [weak self] completion in
-                guard let self = self else {
-                    return
-                }
                 switch completion {
                 case .failure(let error):
                     #if DEBUG
                     print("PriceEngine Api Issue: ", error)
                     #endif
-                    self.potentialPrice = self.fallbackResalePrice()
+                    self?.potentialPrice = self?.fallbackResalePrice()
                 case .finished:
                     print(completion)
                 }
             }, receiveValue: { [weak self] in
-                guard let self = self else {
-                    return
-                }
                 guard let result = $0.result, let resaleValue = result.resaleValue else {
-                    self.potentialPrice = self.fallbackResalePrice()
+                    self?.potentialPrice = self?.fallbackResalePrice()
                     return
                 }
-                self.potentialPrice = String(resaleValue)
+                self?.potentialPrice = String(resaleValue)
             })
     }
 

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -142,13 +142,13 @@ private extension AirRobeOptInViewModel {
                     #if DEBUG
                     print("PriceEngine Api Issue: ", error)
                     #endif
-                    self?.potentialPrice = self?.fallbackResalePrice()
+                    self?.potentialPrice = self?.fallbackResalePrice() ?? ""
                 case .finished:
                     print(completion)
                 }
             }, receiveValue: { [weak self] in
                 guard let result = $0.result, let resaleValue = result.resaleValue else {
-                    self?.potentialPrice = self?.fallbackResalePrice()
+                    self?.potentialPrice = self?.fallbackResalePrice() ?? ""
                     return
                 }
                 self?.potentialPrice = String(resaleValue)

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
@@ -15,7 +15,7 @@ final class AirRobeOrderConfirmationViewModel {
     /// Describes the email of the logged in account.
     var email: String = ""
     /// Describes the sub total amount of the order in cents
-    var orderSubTotalCents: Int?
+    var orderSubtotalCents: Int?
     /// Describes the currency of the order
     var currency: String = "AUD"
     /// Describes the fraud status of the widget.
@@ -56,10 +56,10 @@ final class AirRobeOrderConfirmationViewModel {
                         
                     })
             } else {
-                guard let orderSubTotalCents = orderSubTotalCents, let appId = configuration?.appId else {
+                guard let orderSubtotalCents = orderSubtotalCents, let appId = configuration?.appId else {
                     return
                 }
-                createOptedOutOrder(appId: appId, orderId: orderId, orderSubTotalCents: orderSubTotalCents, currency: currency)
+                createOptedOutOrder(appId: appId, orderId: orderId, orderSubtotalCents: orderSubtotalCents, currency: currency)
             }
         }
     }
@@ -85,8 +85,8 @@ private extension AirRobeOrderConfirmationViewModel {
             })
     }
 
-    func createOptedOutOrder(appId: String, orderId: String, orderSubTotalCents: Int, currency: String) {
-        createOptedOutOrderCancellable = apiService.createOptedOutOrder(operation: AirRobeGraphQLOperation.fetchPost(with: appId, with: orderId, with: orderSubTotalCents, with: currency))
+    func createOptedOutOrder(appId: String, orderId: String, orderSubtotalCents: Int, currency: String) {
+        createOptedOutOrderCancellable = apiService.createOptedOutOrder(operation: AirRobeGraphQLOperation.fetchPost(with: appId, with: orderId, with: orderSubtotalCents, with: currency))
             .sink(receiveCompletion: { (completion) in
                 switch completion {
                 case .failure(let error):

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
@@ -87,7 +87,7 @@ private extension AirRobeOrderConfirmationViewModel {
 
     func createOptedOutOrder(appId: String, orderId: String, orderSubTotalCents: Int, currency: String) {
         createOptedOutOrderCancellable = apiService.createOptedOutOrder(operation: AirRobeGraphQLOperation.fetchPost(with: appId, with: orderId, with: orderSubTotalCents, with: currency))
-            .sink(receiveCompletion: { [weak self] (completion) in
+            .sink(receiveCompletion: { (completion) in
                 switch completion {
                 case .failure(let error):
                     #if DEBUG
@@ -96,7 +96,7 @@ private extension AirRobeOrderConfirmationViewModel {
                 case .finished:
                     print(completion)
                 }
-            }, receiveValue: { [weak self] result in
+            }, receiveValue: { result in
                 #if DEBUG
                 print("Create Opted Out Order Data", result.data.createOptedOutOrder)
                 #endif

--- a/Sources/AirRobeWidget/Widgets/AirRobeConfirmation.swift
+++ b/Sources/AirRobeWidget/Widgets/AirRobeConfirmation.swift
@@ -58,14 +58,14 @@ open class AirRobeConfirmation: UIView {
     public func initialize(
         orderId: String,
         email: String,
-        orderSubTotalCents: Int? = nil,
+        orderSubtotalCents: Int? = nil,
         currency: String = "AUD",
         fraudRisk: Bool = false
     ) {
         translatesAutoresizingMaskIntoConstraints = false
         orderConfirmationView.viewModel.orderId = orderId
         orderConfirmationView.viewModel.email = email
-        orderConfirmationView.viewModel.orderSubTotalCents = orderSubTotalCents
+        orderConfirmationView.viewModel.orderSubtotalCents = orderSubtotalCents
         orderConfirmationView.viewModel.currency = currency
         orderConfirmationView.viewModel.fraudRisk = fraudRisk
         orderConfirmationView.superView = self

--- a/Sources/AirRobeWidget/Widgets/AirRobeConfirmation.swift
+++ b/Sources/AirRobeWidget/Widgets/AirRobeConfirmation.swift
@@ -58,8 +58,8 @@ open class AirRobeConfirmation: UIView {
     public func initialize(
         orderId: String,
         email: String,
-        orderSubTotalCents: Int? = nil
-        currency: String = "AUD"
+        orderSubTotalCents: Int? = nil,
+        currency: String = "AUD",
         fraudRisk: Bool = false
     ) {
         translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/AirRobeWidget/Widgets/AirRobeConfirmation.swift
+++ b/Sources/AirRobeWidget/Widgets/AirRobeConfirmation.swift
@@ -58,11 +58,15 @@ open class AirRobeConfirmation: UIView {
     public func initialize(
         orderId: String,
         email: String,
+        orderSubTotalCents: Int? = nil
+        currency: String = "AUD"
         fraudRisk: Bool = false
     ) {
         translatesAutoresizingMaskIntoConstraints = false
         orderConfirmationView.viewModel.orderId = orderId
         orderConfirmationView.viewModel.email = email
+        orderConfirmationView.viewModel.orderSubTotalCents = orderSubTotalCents
+        orderConfirmationView.viewModel.currency = currency
         orderConfirmationView.viewModel.fraudRisk = fraudRisk
         orderConfirmationView.superView = self
 


### PR DESCRIPTION
## What's updated / implemented
- added `orderSubTotalCents` and `currency` as extra params to the confirmation widget initialization

```swift
    func initialize(
        orderId: String,
        email: String,
        orderSubTotalCents: Int? = nil,
        currency: String = "AUD",
        fraudRisk: Bool = false
    )
```
- createOrderOptedOut mutation Api endpoint implemented with passed params to the confirmation widget
- logic implemented when to call this mutation
```swift
if !UserDefaults.standard.OrderOptedIn || fraudRisk
if !orderId.isEmpty && orderSubTotalCents != nil
```

### What to Test
- [ ] check whether API call gets logged properly to the database.
- [ ] check whether the logic is correct by changing the parameters of the confirmation initialization in all possible ways.

### Test Environment
- Open our demo project through XCode.
- Inside `../AirRobeDemo/Application/AppDelegate -> AppDelegate class -> application()`, we have `initialize` function which has `appId` and `mode` as params.
- Inside `../AirRobeDemo/Controllers/ConfirmationViewController-> ConfirmationViewController class -> viewDidLoad()`, we have `airRobeConfirmation.initialize()` function which has several params.
- Change these params in many ways as we want and see if the build is working as expected.