### PR TITLE
On/Off A/B tests

### DIFF
--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -47,8 +47,8 @@ enum AirRobeStrings {
                       minimumPriceCents
                     }
                     widgetVariants {
-                      enabled
-                      targetSplitTestVariant
+                      disabled
+                      splitTestVariant
                     }
                   }
                 }

--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -46,6 +46,10 @@ enum AirRobeStrings {
                       department
                       minimumPriceCents
                     }
+                    widgetVariants {
+                      enabled
+                      targetSplitTestVariant
+                    }
                   }
                 }
             """
@@ -91,4 +95,8 @@ enum AirRobeStrings {
 
     // MARK: - Delimiter
     static let delimiter: String.Element = "/"
+
+    // MARK: - Target Split Test Variants
+    static let airrobeEnabled = "airrobe-enabled"
+    static let airrobeDisabled = "airrobe-disabled"
 }

--- a/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeStrings.swift
@@ -95,8 +95,4 @@ enum AirRobeStrings {
 
     // MARK: - Delimiter
     static let delimiter: String.Element = "/"
-
-    // MARK: - Target Split Test Variants
-    static let airrobeEnabled = "airrobe-enabled"
-    static let airrobeDisabled = "airrobe-disabled"
 }

--- a/Sources/AirRobeWidget/Resources/AirRobeWidgetLoadState.swift
+++ b/Sources/AirRobeWidget/Resources/AirRobeWidgetLoadState.swift
@@ -7,6 +7,7 @@
 
 enum AirRobeWidgetLoadState: String {
     case initializing = "Widget Initializing"
+    case widgetDisabled = "Widget is not enabled in target variant"
     case noCategoryMappingInfo = "Category Mapping Info is not loaded"
     case eligible
     case notEligible

--- a/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
+++ b/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
@@ -57,7 +57,7 @@ extension AirRobeEndpoint {
             "properties": [
                 "source": AirRobeWidgetInfo.platform,
                 "version": AirRobeWidgetInfo.version,
-                "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.splitTestVariant ?? "default",
+                "split_test_variant": UserDefaults.standard.SplitTestVariant?.splitTestVariant ?? "default",
                 "page_name": pageName,
                 "brand": brand,
                 "material": material,
@@ -79,7 +79,7 @@ extension AirRobeEndpoint {
             "anonymous_id": UIDevice.current.identifierForVendor?.uuidString ?? "",
             "session_id": sessionId,
             "external_order_id": orderId,
-            "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.splitTestVariant ?? "default",
+            "split_test_variant": UserDefaults.standard.SplitTestVariant?.splitTestVariant ?? "default",
             "opted_in": orderOptedIn
         ]
         return AirRobeEndpoint(

--- a/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
+++ b/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
@@ -57,7 +57,7 @@ extension AirRobeEndpoint {
             "properties": [
                 "source": AirRobeWidgetInfo.platform,
                 "version": AirRobeWidgetInfo.version,
-                "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.targetSplitTestVariant ?? "default",
+                "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.splitTestVariant ?? "default",
                 "page_name": pageName,
                 "brand": brand,
                 "material": material,
@@ -79,7 +79,7 @@ extension AirRobeEndpoint {
             "anonymous_id": UIDevice.current.identifierForVendor?.uuidString ?? "",
             "session_id": sessionId,
             "external_order_id": orderId,
-            "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.targetSplitTestVariant ?? "default",
+            "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.splitTestVariant ?? "default",
             "opted_in": orderOptedIn
         ]
         return AirRobeEndpoint(

--- a/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
+++ b/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
@@ -57,7 +57,7 @@ extension AirRobeEndpoint {
             "properties": [
                 "source": AirRobeWidgetInfo.platform,
                 "version": AirRobeWidgetInfo.version,
-                "split_test_variant": "default",
+                "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.targetSplitTestVariant ?? "default",
                 "page_name": pageName,
                 "brand": brand,
                 "material": material,
@@ -79,7 +79,7 @@ extension AirRobeEndpoint {
             "anonymous_id": UIDevice.current.identifierForVendor?.uuidString ?? "",
             "session_id": sessionId,
             "external_order_id": orderId,
-            "split_test_variant": "default",
+            "split_test_variant": UserDefaults.standard.TargetSplitTestVariant?.targetSplitTestVariant ?? "default",
             "opted_in": orderOptedIn
         ]
         return AirRobeEndpoint(

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
@@ -43,8 +43,8 @@ struct AirRobeMinPriceThresholds: Codable {
 
 // MARK: - WidgetVariant
 struct AirRobeWidgetVariant: Codable {
-    let enabled: Bool
-    let targetSplitTestVariant: String?
+    let disabled: Bool
+    let splitTestVariant: String?
 }
 
 // MARK: - HashMap for the Category Mapping
@@ -79,8 +79,8 @@ extension AirRobeGetShoppingDataModel {
     func getTargetSplitTestVariant() -> AirRobeWidgetVariant? {
         if let testVariant = UserDefaults.standard.TargetSplitTestVariant,
            data.shop.widgetVariants.contains(where: {
-               $0.enabled == testVariant.enabled &&
-               $0.targetSplitTestVariant == testVariant.targetSplitTestVariant
+               $0.disabled == testVariant.disabled &&
+               $0.splitTestVariant == testVariant.splitTestVariant
            })
         {
             return testVariant

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
@@ -44,7 +44,7 @@ struct AirRobeMinPriceThresholds: Codable {
 // MARK: - WidgetVariant
 struct AirRobeWidgetVariant: Codable {
     let enabled: Bool
-    let targetSplitTestVariant: String
+    let targetSplitTestVariant: String?
 }
 
 // MARK: - HashMap for the Category Mapping

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
@@ -24,6 +24,7 @@ struct AirRobeShopModel: Codable {
     let popupFindOutMoreUrl: String
     let categoryMappings: [AirRobeCategoryMapping]
     let minimumPriceThresholds: [AirRobeMinPriceThresholds]
+    let widgetVariants: [AirRobeWidgetVariant]
 }
 
 // MARK: - CategoryMapping
@@ -38,6 +39,12 @@ struct AirRobeMinPriceThresholds: Codable {
     let minimumPriceCents: Double
     let department: String?
     let `default`: Bool
+}
+
+// MARK: - WidgetVariant
+struct AirRobeWidgetVariant: Codable {
+    let enabled: Bool
+    let targetSplitTestVariant: String
 }
 
 // MARK: - HashMap for the Category Mapping
@@ -64,6 +71,27 @@ extension AirRobeGetShoppingDataModel {
             return price < (applicablePriceThreshold.minimumPriceCents / 100)
         }
         return false
+    }
+}
+
+// MARK: - Extension for checking target split test variant
+extension AirRobeGetShoppingDataModel {
+    func getTargetSplitTestVariant() -> AirRobeWidgetVariant? {
+        if let testVariant = UserDefaults.standard.TargetSplitTestVariant,
+           data.shop.widgetVariants.contains(where: {
+               $0.enabled == testVariant.enabled &&
+               $0.targetSplitTestVariant == testVariant.targetSplitTestVariant
+           })
+        {
+            return testVariant
+        }
+        if !data.shop.widgetVariants.isEmpty {
+            let testVariant = data.shop.widgetVariants.randomElement()
+            UserDefaults.standard.TargetSplitTestVariant = testVariant
+            return testVariant
+        }
+        UserDefaults.standard.TargetSplitTestVariant = nil
+        return nil
     }
 }
 

--- a/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
+++ b/Sources/AirRobeWidget/Service/ResponseModels/AirRobeGetShoppingDataModel.swift
@@ -76,8 +76,8 @@ extension AirRobeGetShoppingDataModel {
 
 // MARK: - Extension for checking target split test variant
 extension AirRobeGetShoppingDataModel {
-    func getTargetSplitTestVariant() -> AirRobeWidgetVariant? {
-        if let testVariant = UserDefaults.standard.TargetSplitTestVariant,
+    func getSplitTestVariant() -> AirRobeWidgetVariant? {
+        if let testVariant = UserDefaults.standard.SplitTestVariant,
            data.shop.widgetVariants.contains(where: {
                $0.disabled == testVariant.disabled &&
                $0.splitTestVariant == testVariant.splitTestVariant
@@ -87,10 +87,10 @@ extension AirRobeGetShoppingDataModel {
         }
         if !data.shop.widgetVariants.isEmpty {
             let testVariant = data.shop.widgetVariants.randomElement()
-            UserDefaults.standard.TargetSplitTestVariant = testVariant
+            UserDefaults.standard.SplitTestVariant = testVariant
             return testVariant
         }
-        UserDefaults.standard.TargetSplitTestVariant = nil
+        UserDefaults.standard.SplitTestVariant = nil
         return nil
     }
 }

--- a/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
+++ b/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
@@ -75,7 +75,7 @@ struct AirRobeUtils {
             event_name: event,
             source: AirRobeWidgetInfo.platform,
             version: AirRobeWidgetInfo.version,
-            split_test_variant: UserDefaults.standard.TargetSplitTestVariant?.splitTestVariant ?? "default",
+            split_test_variant: UserDefaults.standard.SplitTestVariant?.splitTestVariant ?? "default",
             page_name: PageName.init(rawValue: pageName) ?? .other
         )
 

--- a/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
+++ b/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
@@ -75,7 +75,7 @@ struct AirRobeUtils {
             event_name: event,
             source: AirRobeWidgetInfo.platform,
             version: AirRobeWidgetInfo.version,
-            split_test_variant: "default",
+            split_test_variant: UserDefaults.standard.TargetSplitTestVariant?.targetSplitTestVariant ?? "default",
             page_name: PageName.init(rawValue: pageName) ?? .other
         )
 

--- a/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
+++ b/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
@@ -75,7 +75,7 @@ struct AirRobeUtils {
             event_name: event,
             source: AirRobeWidgetInfo.platform,
             version: AirRobeWidgetInfo.version,
-            split_test_variant: UserDefaults.standard.TargetSplitTestVariant?.targetSplitTestVariant ?? "default",
+            split_test_variant: UserDefaults.standard.TargetSplitTestVariant?.splitTestVariant ?? "default",
             page_name: PageName.init(rawValue: pageName) ?? .other
         )
 

--- a/Sources/AirRobeWidget/Utils/UserDefaults+Extension.swift
+++ b/Sources/AirRobeWidget/Utils/UserDefaults+Extension.swift
@@ -11,7 +11,7 @@ extension UserDefaults {
     enum Key {
         static let OptedInKey = "OptedInKey"
         static let OrderOptedInKey = "OrderOptedInKey"
-        static let TargetSplitTestVariantKey = "TargetSplitTestVariantKey"
+        static let SplitTestVariantKey = "SplitTestVariantKey"
     }
 
     @objc var OptedIn: Bool {
@@ -24,9 +24,9 @@ extension UserDefaults {
         set { set(newValue, forKey: Key.OrderOptedInKey) }
     }
 
-    var TargetSplitTestVariant: AirRobeWidgetVariant? {
-        get { return getCodable(Key.TargetSplitTestVariantKey) }
-        set { setCodable(newValue, forKey: Key.TargetSplitTestVariantKey) }
+    var SplitTestVariant: AirRobeWidgetVariant? {
+        get { return getCodable(Key.SplitTestVariantKey) }
+        set { setCodable(newValue, forKey: Key.SplitTestVariantKey) }
     }
 }
 

--- a/Sources/AirRobeWidget/Utils/UserDefaults+Extension.swift
+++ b/Sources/AirRobeWidget/Utils/UserDefaults+Extension.swift
@@ -11,7 +11,7 @@ extension UserDefaults {
     enum Key {
         static let OptedInKey = "OptedInKey"
         static let OrderOptedInKey = "OrderOptedInKey"
-        static let TargetSplitTestVariantKey = "TargetSplitTestVariant"
+        static let TargetSplitTestVariantKey = "TargetSplitTestVariantKey"
     }
 
     @objc var OptedIn: Bool {

--- a/Sources/AirRobeWidget/Utils/UserDefaults+Extension.swift
+++ b/Sources/AirRobeWidget/Utils/UserDefaults+Extension.swift
@@ -8,15 +8,49 @@
 import Foundation
 
 extension UserDefaults {
-    static let OptedInKey = "OptedInKey"
-    @objc var OptedIn: Bool {
-        get { return bool(forKey: UserDefaults.OptedInKey) }
-        set { set(newValue, forKey: UserDefaults.OptedInKey) }
+    enum Key {
+        static let OptedInKey = "OptedInKey"
+        static let OrderOptedInKey = "OrderOptedInKey"
+        static let TargetSplitTestVariantKey = "TargetSplitTestVariant"
     }
 
-    static let OrderOptedInKey = "OrderOptedInKey"
+    @objc var OptedIn: Bool {
+        get { return bool(forKey: Key.OptedInKey) }
+        set { set(newValue, forKey: Key.OptedInKey) }
+    }
+
     var OrderOptedIn: Bool {
-        get { return bool(forKey: UserDefaults.OrderOptedInKey) }
-        set { set(newValue, forKey: UserDefaults.OrderOptedInKey) }
+        get { return bool(forKey: Key.OrderOptedInKey) }
+        set { set(newValue, forKey: Key.OrderOptedInKey) }
+    }
+
+    var TargetSplitTestVariant: AirRobeWidgetVariant? {
+        get { return getCodable(Key.TargetSplitTestVariantKey) }
+        set { setCodable(newValue, forKey: Key.TargetSplitTestVariantKey) }
+    }
+}
+
+extension UserDefaults {
+    func getCodable<T: Codable>(_ key: String) -> T? {
+        if let savedData = object(forKey: key) as? Data {
+            do {
+                let loadedData = try JSONDecoder().decode(T.self, from: savedData)
+                return loadedData
+            } catch {
+                print(String(describing: error))
+                return nil
+            }
+        } else {
+            return nil
+        }
+    }
+
+    func setCodable<T: Codable>(_ value: T?, forKey key: String) {
+        do {
+            let encoded = try JSONEncoder().encode(value)
+            set(encoded, forKey: key)
+        } catch {
+            print(String(describing: error))
+        }
     }
 }

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInView.swift
@@ -249,6 +249,10 @@ private extension AirRobeOptInView {
                     #if DEBUG
                     print(AirRobeWidgetLoadState.initializing.rawValue)
                     #endif
+                case .widgetDisabled:
+                    #if DEBUG
+                    print(AirRobeWidgetLoadState.widgetDisabled.rawValue)
+                    #endif
                 case .noCategoryMappingInfo:
                     #if DEBUG
                     print(AirRobeWidgetLoadState.noCategoryMappingInfo.rawValue)

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -48,7 +48,7 @@ final class AirRobeOptInViewModel {
             return
         }
 
-        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), !testVariant.enabled {
+        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), testVariant.disabled {
             isAllSet = .widgetDisabled
             AirRobeUtils.telemetryEvent(
                 eventName: TelemetryEventName.pageView.rawValue,
@@ -106,7 +106,7 @@ final class AirRobeOptInViewModel {
             return
         }
 
-        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), !testVariant.enabled {
+        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), testVariant.disabled {
             isAllSet = .widgetDisabled
             AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.cart.rawValue)
             AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.cart.rawValue)

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -48,7 +48,7 @@ final class AirRobeOptInViewModel {
             return
         }
 
-        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), testVariant.disabled {
+        if let testVariant = shoppingDataModel.getSplitTestVariant(), testVariant.disabled {
             isAllSet = .widgetDisabled
             AirRobeUtils.telemetryEvent(
                 eventName: TelemetryEventName.pageView.rawValue,
@@ -106,7 +106,7 @@ final class AirRobeOptInViewModel {
             return
         }
 
-        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), testVariant.disabled {
+        if let testVariant = shoppingDataModel.getSplitTestVariant(), testVariant.disabled {
             isAllSet = .widgetDisabled
             AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.cart.rawValue)
             AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.cart.rawValue)

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -48,6 +48,12 @@ final class AirRobeOptInViewModel {
             return
         }
 
+        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(),
+           testVariant.targetSplitTestVariant == AirRobeStrings.airrobeDisabled && !testVariant.enabled {
+            isAllSet = .widgetDisabled
+            return
+        }
+
         if !alreadyInitialized {
             AirRobeUtils.telemetryEvent(
                 eventName: TelemetryEventName.pageView.rawValue,
@@ -84,11 +90,17 @@ final class AirRobeOptInViewModel {
 
     func initializeMultiOptInWidget() {
         guard
-            AirRobeShoppingDataModelInstance.shared.shoppingDataModel != nil,
+            let shoppingDataModel = AirRobeShoppingDataModelInstance.shared.shoppingDataModel,
             !AirRobeShoppingDataModelInstance.shared.categoryMapping.categoryMappingsHashMap.isEmpty
         else {
             isAllSet = .noCategoryMappingInfo
             UserDefaults.standard.OrderOptedIn = false
+            return
+        }
+
+        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(),
+           testVariant.targetSplitTestVariant == AirRobeStrings.airrobeDisabled && !testVariant.enabled {
+            isAllSet = .widgetDisabled
             return
         }
 

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -48,8 +48,7 @@ final class AirRobeOptInViewModel {
             return
         }
 
-        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(),
-           testVariant.targetSplitTestVariant == AirRobeStrings.airrobeDisabled && !testVariant.enabled {
+        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), !testVariant.enabled {
             isAllSet = .widgetDisabled
             return
         }
@@ -98,8 +97,7 @@ final class AirRobeOptInViewModel {
             return
         }
 
-        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(),
-           testVariant.targetSplitTestVariant == AirRobeStrings.airrobeDisabled && !testVariant.enabled {
+        if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), !testVariant.enabled {
             isAllSet = .widgetDisabled
             return
         }

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -50,6 +50,15 @@ final class AirRobeOptInViewModel {
 
         if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), !testVariant.enabled {
             isAllSet = .widgetDisabled
+            AirRobeUtils.telemetryEvent(
+                eventName: TelemetryEventName.pageView.rawValue,
+                pageName: PageName.product.rawValue,
+                brand: brand,
+                material: material,
+                category: category,
+                department: department
+            )
+            AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.product.rawValue)
             return
         }
 
@@ -99,6 +108,8 @@ final class AirRobeOptInViewModel {
 
         if let testVariant = shoppingDataModel.getTargetSplitTestVariant(), !testVariant.enabled {
             isAllSet = .widgetDisabled
+            AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.cart.rawValue)
+            AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.cart.rawValue)
             return
         }
 

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationView.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationView.swift
@@ -81,6 +81,10 @@ private extension AirRobeOrderConfirmationView {
                     #if DEBUG
                     print(AirRobeWidgetLoadState.initializing.rawValue)
                     #endif
+                case .widgetDisabled:
+                    #if DEBUG
+                    print(AirRobeWidgetLoadState.widgetDisabled.rawValue)
+                    #endif
                 case .noCategoryMappingInfo:
                     #if DEBUG
                     print(AirRobeWidgetLoadState.noCategoryMappingInfo.rawValue)

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
@@ -29,6 +29,12 @@ final class AirRobeOrderConfirmationViewModel {
     @Published var activateText: String = ""
 
     func initializeConfirmationWidget() {
+        if let testVariant = AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.getTargetSplitTestVariant(),
+           testVariant.targetSplitTestVariant == AirRobeStrings.airrobeDisabled && !testVariant.enabled {
+            isAllSet = .widgetDisabled
+            return
+        }
+
         if !alreadyInitialized {
             AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.thankYou.rawValue)
             AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.thankYou.rawValue)

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
@@ -32,6 +32,8 @@ final class AirRobeOrderConfirmationViewModel {
         if let testVariant = AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.getTargetSplitTestVariant(),
            !testVariant.enabled {
             isAllSet = .widgetDisabled
+            AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.thankYou.rawValue)
+            AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.thankYou.rawValue)
             return
         }
 

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
@@ -30,7 +30,7 @@ final class AirRobeOrderConfirmationViewModel {
 
     func initializeConfirmationWidget() {
         if let testVariant = AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.getTargetSplitTestVariant(),
-           testVariant.targetSplitTestVariant == AirRobeStrings.airrobeDisabled && !testVariant.enabled {
+           !testVariant.enabled {
             isAllSet = .widgetDisabled
             return
         }

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
@@ -30,7 +30,7 @@ final class AirRobeOrderConfirmationViewModel {
 
     func initializeConfirmationWidget() {
         if let testVariant = AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.getTargetSplitTestVariant(),
-           !testVariant.enabled {
+           testVariant.disabled {
             isAllSet = .widgetDisabled
             AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.thankYou.rawValue)
             AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.thankYou.rawValue)

--- a/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OrderConfirmationView/AirRobeOrderConfirmationViewModel.swift
@@ -29,7 +29,7 @@ final class AirRobeOrderConfirmationViewModel {
     @Published var activateText: String = ""
 
     func initializeConfirmationWidget() {
-        if let testVariant = AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.getTargetSplitTestVariant(),
+        if let testVariant = AirRobeShoppingDataModelInstance.shared.shoppingDataModel?.getSplitTestVariant(),
            testVariant.disabled {
             isAllSet = .widgetDisabled
             AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.thankYou.rawValue)


### PR DESCRIPTION
### Context
Implemented query and logic to support on/off A/B tests.

### What's updated/implemented
- widget variant i.e. enabled/disabled query implemented
- widgets render/not render logic implemented
- minor fixes

### Considerations
- Not sure if `enabled`, `targetSplitTestVariant` variable names from widgetVariants of the response would change, Or likely be removed in the future, And also the possibility to have other variables in response.
- Not sure If the widget would be rendered if the variant is not chosen and no variant is available from the response of the query.

### Release type
- [ ] Patch
- [ ] Minor
- [x] Major

### Peer review
- [x] The feature/changes have been peer reviewed
- [ ] Automated test coverage and correctness have been peer reviewed
- [ ] The test plan has been peer reviewed
