### PR TITLE
Add data for pageview event for multi opt-in

### DIFF
--- a/Sources/AirRobeWidget/Service/AirRobeApiService.swift
+++ b/Sources/AirRobeWidget/Service/AirRobeApiService.swift
@@ -75,7 +75,8 @@ final class AirRobeApiService: AirRobeNetworkClient {
         brand: String? = nil,
         material: String? = nil,
         category: String? = nil,
-        department: String? = nil
+        department: String? = nil,
+        itemCount: Int? = nil
     ) -> AnyPublisher<AirRobeTelemetryEventResponseModel, Error> {
         var endpoint = AirRobeEndpoint.telemetryEvent(
             eventName: eventName,
@@ -83,7 +84,8 @@ final class AirRobeApiService: AirRobeNetworkClient {
             brand: brand,
             material: material,
             category: category,
-            department: department
+            department: department,
+            itemCount: itemCount
         )
         endpoint.requestBody = endpoint.requestBody.merging(additionalRequestBodyParams) { (current, _) in current }
         #if DEBUG

--- a/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
+++ b/Sources/AirRobeWidget/Service/Endpoints/AirRobeWidgetEndpoints.swift
@@ -47,7 +47,8 @@ extension AirRobeEndpoint {
         brand: String? = nil,
         material: String? = nil,
         category: String? = nil,
-        department: String? = nil
+        department: String? = nil,
+        itemCount: Int? = nil
     ) -> AirRobeEndpoint {
         let requestBody: [String: Any] = [
             "app_id": configuration?.appId ?? "",
@@ -62,7 +63,8 @@ extension AirRobeEndpoint {
                 "brand": brand,
                 "material": material,
                 "category": category,
-                "department": department
+                "department": department,
+                "itemCount": itemCount
             ]
         ]
         return AirRobeEndpoint(

--- a/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
+++ b/Sources/AirRobeWidget/Utils/AirRobeUtils.swift
@@ -38,7 +38,8 @@ struct AirRobeUtils {
         brand: String? = nil,
         material: String? = nil,
         category: String? = nil,
-        department: String? = nil
+        department: String? = nil,
+        itemCount: Int? = nil
     ) {
         let apiService = AirRobeApiService()
         cancellable = apiService.telemetryEvent(
@@ -47,7 +48,8 @@ struct AirRobeUtils {
             brand: brand,
             material: material,
             category: category,
-            department: department
+            department: department,
+            itemCount: itemCount
         )
             .sink(receiveCompletion: { completion in
                 switch completion {

--- a/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
+++ b/Sources/AirRobeWidget/Views/OptInView/AirRobeOptInViewModel.swift
@@ -93,7 +93,7 @@ final class AirRobeOptInViewModel {
         }
 
         if !alreadyInitialized {
-            AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.cart.rawValue)
+            AirRobeUtils.telemetryEvent(eventName: TelemetryEventName.pageView.rawValue, pageName: PageName.cart.rawValue, itemCount: items.count)
             AirRobeUtils.dispatchEvent(eventName: EventName.pageView.rawValue, pageName: PageName.cart.rawValue)
             alreadyInitialized = true
         }


### PR DESCRIPTION
### Context
added item count to the telemetry event for the pageview event in the multi-optin widget.

### What's updated/implemented
- added item count to the telemetry event for the pageview event in multi optin widget

### Considerations
Need to test it through the connector if it is logged properly.

### Release type
- [ ] Patch
- [x] Minor
- [ ] Major

### Peer review
- [x] The feature/changes have been peer reviewed
- [ ] Automated test coverage and correctness have been peer reviewed
- [ ] The test plan has been peer reviewed